### PR TITLE
ci: deduplicate exact-head agent reviews

### DIFF
--- a/.github/workflows/agent-review-request.yml
+++ b/.github/workflows/agent-review-request.yml
@@ -36,8 +36,21 @@ jobs:
             if test "$reviewed" != true; then
               if ! gh api --method POST "repos/${GITHUB_REPOSITORY}/pulls/${pr_number}/requested_reviewers" \
                 --input - <<< '{"reviewers":["copilot-pull-request-reviewer[bot]"]}'; then
-                echo "Copilot review request unavailable; dispatching GitHub-hosted pinned local-model fallback"
+                echo "Copilot review request unavailable; GitHub-hosted pinned local-model fallback remains authoritative"
               fi
+            fi
+            if test -n "${EVENT_PR}"; then
+              echo "Direct pull-request event already launches the fallback; skipping duplicate dispatch"
+              continue
+            fi
+            exact_review_active="$(gh api \
+              "repos/${GITHUB_REPOSITORY}/commits/${head_sha}/check-runs?check_name=agent-review" \
+              | jq -r --arg external_id "agent-review:pr:${pr_number}:head:${head_sha}:" \
+                '[.check_runs[] | select(.external_id != null and (.external_id | startswith($external_id)))]
+                 | any(.[]; .status == "in_progress" or .conclusion == "success")')"
+            if test "$exact_review_active" = true; then
+              echo "Exact-head agent review is already running or successful; skipping fallback dispatch"
+              continue
             fi
             gh workflow run agent-review.yml --repo "$GITHUB_REPOSITORY" --ref main \
               -f pr_number="$pr_number" -f head_sha="$head_sha"

--- a/.github/workflows/agent-review.yml
+++ b/.github/workflows/agent-review.yml
@@ -23,6 +23,10 @@ permissions:
   contents: read
   pull-requests: read
 
+concurrency:
+  group: agent-review-${{ github.event.pull_request.number || inputs.pr_number }}-${{ github.event.pull_request.head.sha || inputs.head_sha }}
+  cancel-in-progress: false
+
 jobs:
   agent-review-orchestrator:
     runs-on: ubuntu-latest
@@ -40,6 +44,17 @@ jobs:
           PR_NUMBER: ${{ github.event.pull_request.number || inputs.pr_number }}
         run: |
           set -euo pipefail
+          pr_json="$(gh api "repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}")"
+          test "$(jq -r '.head.sha' <<< "$pr_json")" = "$HEAD_SHA"
+          existing_success="$(gh api \
+            "repos/${GITHUB_REPOSITORY}/commits/${HEAD_SHA}/check-runs?check_name=agent-review" \
+            | jq -r --arg external_id "agent-review:pr:${PR_NUMBER}:head:${HEAD_SHA}:" \
+              '[.check_runs[] | select(.external_id != null and (.external_id | startswith($external_id)))]
+               | any(.[]; .conclusion == "success")')"
+          if test "$existing_success" = true; then
+            echo "Exact-head agent review is already successful; skipping duplicate run"
+            exit 0
+          fi
           check_id="$(gh api --method POST "repos/${GITHUB_REPOSITORY}/check-runs" \
             -f name='agent-review' -f head_sha="$HEAD_SHA" -f status='in_progress' \
             -f external_id="agent-review:pr:${PR_NUMBER}:head:${HEAD_SHA}:run:${GITHUB_RUN_ID}" \
@@ -68,8 +83,6 @@ jobs:
           }
           trap finish_check EXIT
 
-          pr_json="$(gh api "repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}")"
-          test "$(jq -r '.head.sha' <<< "$pr_json")" = "$HEAD_SHA"
           for attempt in $(seq 1 7); do
             copilot_reviewed="$(gh api --paginate "repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}/reviews" \
               | jq -s -r --arg head "$HEAD_SHA" \

--- a/src/master-plan-controller/__tests__/workflow-governance.test.ts
+++ b/src/master-plan-controller/__tests__/workflow-governance.test.ts
@@ -88,6 +88,8 @@ describe('blocking CI and governed workflows', () => {
       expect(mergeRequest).toContain(protectedPattern);
     }
     expect(agentReview).toContain("name='agent-review'");
+    expect(agentReview).toContain('group: agent-review-${{ github.event.pull_request.number || inputs.pr_number }}-${{ github.event.pull_request.head.sha || inputs.head_sha }}');
+    expect(agentReview).toContain('cancel-in-progress: false');
     expect(agentReview).toContain('pull_request_target:');
     expect(agentReview).toContain('workflow_dispatch:');
     expect(agentReview).toContain('external_id');
@@ -95,6 +97,8 @@ describe('blocking CI and governed workflows', () => {
     expect(agentReview).toContain('commit_id');
     expect(agentReview).toContain('checks: write');
     expect(agentReview).toContain('/check-runs');
+    expect(agentReview).toContain('Exact-head agent review is already successful; skipping duplicate run');
+    expect(agentReview.indexOf('existing_success=')).toBeLessThan(agentReview.indexOf('check_id='));
     expect(agentReview).toContain('head.sha');
     expect(agentReview).toContain('llama-b10242-bin-ubuntu-x64.tar.gz');
     expect(agentReview).toContain('fb13c9fa97a605c6bba16a99b2f54eff6874d58bdbe5b94ece6e358eaa270088');
@@ -126,6 +130,10 @@ describe('blocking CI and governed workflows', () => {
     expect(agentReviewRequest).toContain('if ! gh api --method POST');
     expect(agentReviewRequest).toContain('gh workflow run agent-review.yml');
     expect(agentReviewRequest).toContain('GitHub-hosted pinned local-model fallback');
+    expect(agentReviewRequest).toContain('Direct pull-request event already launches the fallback');
+    expect(agentReviewRequest).toContain('commits/${head_sha}/check-runs?check_name=agent-review');
+    expect(agentReviewRequest).toContain('.status == "in_progress" or .conclusion == "success"');
+    expect(agentReviewRequest).toContain('Exact-head agent review is already running or successful; skipping fallback dispatch');
     expect(mergeRequest).toContain('workflow_dispatch:');
     expect(agentReviewRequest).not.toContain('actions/checkout');
     expect(agentReviewRequest).not.toContain('npm ci');


### PR DESCRIPTION
Prevents redundant local-model reviewer runs from resetting the required `agent-review` check on the same PR head.

- pull-request events rely on the fallback workflow they already trigger
- scheduled retries skip an exact-head review that is running or successful
- failed or absent exact-head reviews remain retryable
- adds governance regression assertions first

Validation:
- full test suite passed
- `npm run lint`
- `npm run strategy:verify`
- `git diff --check`

This protected workflow change is confined to one commit.