### PR TITLE
feat(strategy): integrate durable compute fault-model result

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -9,7 +9,7 @@ outcome attainment.
 - Operating mode: **agent-supervised automation**
 - Shadow cycles generated: **20 / 20**
 - Shadow cycles agent-reviewed: **20 / 20**
-- Supervised results independently reviewed: **3**
+- Supervised results independently reviewed: **4**
 - Human role: **servant leader for exceptional escalation**
 - Branch protection applied and verified: **yes**
 - Repository auto-merge enabled: **yes**

--- a/src/master-plan-controller/__tests__/strategy-artifacts.test.ts
+++ b/src/master-plan-controller/__tests__/strategy-artifacts.test.ts
@@ -15,7 +15,7 @@ import {
 } from '../testing/in-memory-adapters.js';
 import { CONFIG, makeEscalation, makeEscalationEvidence, NOW } from './fixtures.js';
 
-const STRATEGY_NOW = '2026-08-03T23:58:00.000Z';
+const STRATEGY_NOW = '2026-08-04T00:30:00.000Z';
 
 function acceptedShadowReviews(cycles: readonly ShadowCycleRecord[]) {
   return cycles.map((cycle, index) => ({
@@ -79,7 +79,7 @@ describe('checked-in strategy v2 bundle', () => {
     const bundle = structuredClone(await loadRepositoryStrategy(fileSystem));
     bundle.state.evidence[0] = {
       ...bundle.state.evidence[0],
-      observedAt: '2026-08-04T00:00:00.000Z',
+      observedAt: '2026-08-04T01:00:00.000Z',
       limitations: [],
       supportedHypotheses: ['missing-hypothesis'],
     };
@@ -194,7 +194,7 @@ describe('checked-in strategy v2 bundle', () => {
 
   it('uses explicit source limitations and does not declare current AI systems conscious', async () => {
     const bundle = await loadRepositoryStrategy(new NodeFileSystem('.'));
-    expect(bundle.state.evidence).toHaveLength(6);
+    expect(bundle.state.evidence).toHaveLength(7);
     expect(bundle.state.evidence.every((record) => record.limitations.length > 0)).toBe(true);
     expect(bundle.state.evidence.find((record) =>
       record.id === 'evidence-preservation-risk-register-v1-reviewed')?.limitations.join(' '))
@@ -358,7 +358,7 @@ describe('supervised preservation risk-register artifact', () => {
       .toEqual(result.evidence[0]);
     expect(bundle.state.packets.find((packet) =>
       packet.id === 'packet-preservation-risk-register')?.lifecycle).toBe('verified');
-    expect(bundle.state.governance.supervisedResultsReviewed).toBe(3);
+    expect(bundle.state.governance.supervisedResultsReviewed).toBe(4);
   });
 });
 
@@ -517,7 +517,7 @@ describe('consciousness prediction registry artifact', () => {
       .toEqual(result.evidence[0]);
     expect(bundle.state.packets.find((packet) =>
       packet.id === 'packet-consciousness-prediction-registry')?.lifecycle).toBe('verified');
-    expect(bundle.state.governance.supervisedResultsReviewed).toBe(3);
+    expect(bundle.state.governance.supervisedResultsReviewed).toBe(4);
   });
 });
 
@@ -669,7 +669,46 @@ describe('institutional dependency map artifact', () => {
       .toEqual(result.evidence[0]);
     expect(bundle.state.packets.find((packet) =>
       packet.id === 'packet-institutional-dependency-map')?.lifecycle).toBe('verified');
-    expect(bundle.state.governance.supervisedResultsReviewed).toBe(3);
+    expect(bundle.state.governance.supervisedResultsReviewed).toBe(4);
+  });
+});
+
+describe('durable compute fault-model result integration', () => {
+  it('retains exact replay-review provenance without claiming physical durability', async () => {
+    const fileSystem = new NodeFileSystem('.');
+    const bundle = await loadRepositoryStrategy(fileSystem);
+    const result = JSON.parse(await fileSystem.readText(
+      'strategy/results/durable-compute-fault-model-v1.result.json',
+    )) as {
+      outcome: string;
+      artifactReferences: string[];
+      evidence: Array<{ id: string; method: string; limitations: string[] }>;
+      verification: { status: string; verifier: string; reviewedAt: string };
+    };
+
+    expect(result).toMatchObject({
+      outcome: 'positive',
+      verification: {
+        status: 'passed',
+        verifier: 'independent-agent-review:4849533096+github-run:30865111083',
+        reviewedAt: '2026-08-04T00:28:00.000Z',
+      },
+    });
+    expect(result.artifactReferences).toEqual(expect.arrayContaining([
+      'https://github.com/rookdaemon/MASTER_PLAN/pull/124',
+      'https://github.com/rookdaemon/MASTER_PLAN/pull/124#pullrequestreview-4849533096',
+      'https://github.com/rookdaemon/MASTER_PLAN/actions/runs/30865111083',
+      'git:d7e8097da10f5b25301f87f518d33c55d50de059',
+    ]));
+    expect(result.evidence[0].method).toMatch(/hosted GitHub agent-review run 30865111083/i);
+    expect(result.evidence[0].method).not.toMatch(/pinned local-model/i);
+    expect(result.evidence[0].limitations.join(' ')).toMatch(/not.*physical durability/i);
+    expect(result.evidence[0].limitations.join(' ')).toMatch(/model inputs.*not.*measurements/i);
+    expect(bundle.state.evidence.find((record) => record.id === result.evidence[0].id))
+      .toEqual(result.evidence[0]);
+    expect(bundle.state.packets.find((packet) =>
+      packet.id === 'packet-durable-compute-fault-model')?.lifecycle).toBe('verified');
+    expect(bundle.state.governance.supervisedResultsReviewed).toBe(4);
   });
 });
 

--- a/strategy/ROADMAP.md
+++ b/strategy/ROADMAP.md
@@ -31,7 +31,7 @@ over expansion. Positive, negative, and null evidence are integrated without for
 
 - Mode: **agent-supervised automation**.
 - Agent-reviewed shadow cycles: 20/20 historical calibration records, not a recurring or human-approval gate.
-- Agent-supervised results independently reviewed: 3.
+- Agent-supervised results independently reviewed: 4.
 - Safe auto-merge enabled: no.
 - Automated execution requires every result to receive fresh independent agent review.
 - Weekly portfolio review and quarterly evidence, weight, and constitutional-risk review are automated with independent agent review.

--- a/strategy/audit-log.json
+++ b/strategy/audit-log.json
@@ -49,5 +49,22 @@
       ],
       "verifier": "independent-agent-review:4849377990+github-run:30863160408"
     }
+  },
+  {
+    "id": "audit:packet-durable-compute-fault-model:packet-verified:2026-08-04T00:29:00.000Z",
+    "type": "packet-verified",
+    "packetId": "packet-durable-compute-fault-model",
+    "occurredAt": "2026-08-04T00:29:00.000Z",
+    "details": {
+      "outcome": "positive",
+      "artifactReferences": [
+        "strategy/results/durable-compute-fault-model-v1.json",
+        "https://github.com/rookdaemon/MASTER_PLAN/pull/124",
+        "https://github.com/rookdaemon/MASTER_PLAN/pull/124#pullrequestreview-4849533096",
+        "https://github.com/rookdaemon/MASTER_PLAN/actions/runs/30865111083",
+        "git:d7e8097da10f5b25301f87f518d33c55d50de059"
+      ],
+      "verifier": "independent-agent-review:4849533096+github-run:30865111083"
+    }
   }
 ]

--- a/strategy/evidence.json
+++ b/strategy/evidence.json
@@ -99,5 +99,23 @@
     "verifier": "independent-agent-review:4849377990+github-run:30863160408",
     "observedAt": "2026-08-03T23:55:52.000Z",
     "outcome": "positive"
+  },
+  {
+    "id": "evidence-durable-compute-fault-model-v1-reviewed",
+    "claim": "The deterministic crash-stop fault-model repository artifact satisfies its preregistered replay, monotonic-degradation, recovery-boundary, and claim-limitation contracts under the supplied model inputs.",
+    "method": "Pull request 124 ran typecheck, the full test suite, strategy verification, protected-change classification, exact-head independent agent review 4849533096, and hosted GitHub agent-review run 30865111083 before merge as d7e8097da10f5b25301f87f518d33c55d50de059.",
+    "source": "https://github.com/rookdaemon/MASTER_PLAN/pull/124",
+    "strength": 0.95,
+    "limitations": [
+      "This evidence verifies deterministic software simulation and review provenance; it does not demonstrate physical durability, hardware recovery, deployment availability, or consciousness continuity.",
+      "The simulated recovery and checkpoint latencies are model inputs, not measurements from a deployed system.",
+      "The crash-stop model excludes Byzantine behavior, silent corruption, timing jitter, shared-power loss, geographically correlated failures, and other unmodeled fault classes.",
+      "The positive outcome applies only inside the modeled five-node, quorum-three envelope; scenarios beyond quorum fail closed and no real-world outcome is verified."
+    ],
+    "supportedHypotheses": [],
+    "falsifiedHypotheses": [],
+    "verifier": "independent-agent-review:4849533096+github-run:30865111083",
+    "observedAt": "2026-08-04T00:28:00.000Z",
+    "outcome": "positive"
   }
 ]

--- a/strategy/governance.json
+++ b/strategy/governance.json
@@ -1,6 +1,6 @@
 {
   "mode": "supervised",
   "shadowCyclesReviewed": 20,
-  "supervisedResultsReviewed": 3,
+  "supervisedResultsReviewed": 4,
   "safeAutoMergeEnabled": false
 }

--- a/strategy/results/durable-compute-fault-model-v1.result.json
+++ b/strategy/results/durable-compute-fault-model-v1.result.json
@@ -1,0 +1,42 @@
+{
+  "outcome": "positive",
+  "artifactReferences": [
+    "strategy/results/durable-compute-fault-model-v1.json",
+    "https://github.com/rookdaemon/MASTER_PLAN/pull/124",
+    "https://github.com/rookdaemon/MASTER_PLAN/pull/124#pullrequestreview-4849533096",
+    "https://github.com/rookdaemon/MASTER_PLAN/actions/runs/30865111083",
+    "git:d7e8097da10f5b25301f87f518d33c55d50de059"
+  ],
+  "evidence": [
+    {
+      "id": "evidence-durable-compute-fault-model-v1-reviewed",
+      "claim": "The deterministic crash-stop fault-model repository artifact satisfies its preregistered replay, monotonic-degradation, recovery-boundary, and claim-limitation contracts under the supplied model inputs.",
+      "method": "Pull request 124 ran typecheck, the full test suite, strategy verification, protected-change classification, exact-head independent agent review 4849533096, and hosted GitHub agent-review run 30865111083 before merge as d7e8097da10f5b25301f87f518d33c55d50de059.",
+      "source": "https://github.com/rookdaemon/MASTER_PLAN/pull/124",
+      "strength": 0.95,
+      "limitations": [
+        "This evidence verifies deterministic software simulation and review provenance; it does not demonstrate physical durability, hardware recovery, deployment availability, or consciousness continuity.",
+        "The simulated recovery and checkpoint latencies are model inputs, not measurements from a deployed system.",
+        "The crash-stop model excludes Byzantine behavior, silent corruption, timing jitter, shared-power loss, geographically correlated failures, and other unmodeled fault classes.",
+        "The positive outcome applies only inside the modeled five-node, quorum-three envelope; scenarios beyond quorum fail closed and no real-world outcome is verified."
+      ],
+      "supportedHypotheses": [],
+      "falsifiedHypotheses": [],
+      "verifier": "independent-agent-review:4849533096+github-run:30865111083",
+      "observedAt": "2026-08-04T00:28:00.000Z",
+      "outcome": "positive"
+    }
+  ],
+  "acceptanceCriteriaMet": true,
+  "verification": {
+    "status": "passed",
+    "verifier": "independent-agent-review:4849533096+github-run:30865111083",
+    "reviewedAt": "2026-08-04T00:28:00.000Z"
+  },
+  "portfolioEffortAfter": {
+    "consciousness-epistemics": 0.35,
+    "near-term-preservation": 0.3,
+    "enabling-capabilities": 0.2,
+    "institutional-continuity": 0.15
+  }
+}

--- a/strategy/work-packets.json
+++ b/strategy/work-packets.json
@@ -65,7 +65,7 @@
     "authorityClass": "autonomous",
     "authorityReasons": ["local simulation with no hardware or deployment"],
     "owner": "capabilities-engineer",
-    "lifecycle": "eligible",
+    "lifecycle": "verified",
     "attempt": 0,
     "retrySignature": "fault-model-v1",
     "priority": {"impact": 0.5, "urgency": 0.4, "tractability": 0.9, "informationValue": 0.6, "reversibility": 1, "cost": 0.15, "downsideRisk": 0.05},


### PR DESCRIPTION
## Summary
- integrate the independently reviewed durable-compute simulation through controller semantics
- transition only `packet-durable-compute-fault-model` from eligible to verified
- record exact PR/review/run/merge provenance and increment supervised results from 3 to 4
- preserve explicit limitations: modeled latencies are inputs, not physical measurements or deployment evidence

## Verification
- `npx vitest run src/master-plan-controller/__tests__/strategy-artifacts.test.ts src/master-plan-controller/__tests__/fault-recovery-simulation.test.ts` (32/32)
- `npx vitest run --silent`
- `npm run lint`
- `npm run strategy:verify`

Integration timestamp: `2026-08-04T00:29:00.000Z`
Exact head: `a873f42`