### PR TITLE
Automate diagnosis-driven packet generation

### DIFF
--- a/src/master-plan-controller/__tests__/packet-generation.test.ts
+++ b/src/master-plan-controller/__tests__/packet-generation.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, it } from 'vitest';
+import {
+  DiagnosticPacketGenerator,
+  type DiagnosticPacketTemplate,
+  type DiagnosticTrigger,
+} from '../packet-generation.js';
+import { makePacket, makeState, NOW } from './fixtures.js';
+import type { GraphDiagnosis, WorkPacket } from '../types.js';
+
+function template(id: string, trigger: DiagnosticTrigger): DiagnosticPacketTemplate {
+  const packet = makePacket({
+    id,
+    ...('nodeId' in trigger ? { nodeId: trigger.nodeId } : { portfolio: trigger.portfolio }),
+  });
+  const { lifecycle: _lifecycle, attempt: _attempt, reviewedAt: _reviewedAt, ...definition } = packet;
+  return { ...definition, trigger };
+}
+
+const DIAGNOSIS: GraphDiagnosis = {
+  evaluatedNodeCount: 4,
+  bottlenecks: [{ nodeId: 'capability-1', gateFailures: ['dependency'], downstreamDependents: 2 }],
+  highValueUncertainties: [{ nodeId: 'capability-1', uncertainty: 0.7, directiveReach: 2 }],
+  neglectedPortfolios: [{ portfolio: 'consciousness-epistemics', allocationGap: 0.1 }],
+  failureModes: [{ nodeId: 'capability-1', lifecycle: 'blocked' }],
+};
+
+describe('DiagnosticPacketGenerator', () => {
+  it('matches templates across every diagnosis channel and binds lifecycle fields to the supplied timestamp', async () => {
+    const templates = [
+      template('uncertainty', { kind: 'high-value-uncertainty', nodeId: 'capability-1' }),
+      template('bottleneck', { kind: 'bottleneck', nodeId: 'capability-1' }),
+      template('portfolio', { kind: 'neglected-portfolio', portfolio: 'consciousness-epistemics' }),
+      template('failure', { kind: 'failure-mode', nodeId: 'capability-1' }),
+    ];
+
+    const generated = await new DiagnosticPacketGenerator(templates, 4)
+      .generate(makeState({ packets: [] }), DIAGNOSIS, NOW);
+
+    expect(generated.map((packet) => packet.id)).toEqual(['bottleneck', 'failure', 'portfolio', 'uncertainty']);
+    expect(generated.every((packet) =>
+      packet.lifecycle === 'eligible' && packet.attempt === 0 && packet.reviewedAt === NOW)).toBe(true);
+  });
+
+  it('does not regenerate an existing identity or emit an unmatched template', async () => {
+    const existing = makePacket({ id: 'uncertainty', lifecycle: 'verified' });
+    const generator = new DiagnosticPacketGenerator([
+      template('uncertainty', { kind: 'high-value-uncertainty', nodeId: 'capability-1' }),
+      template('unmatched', { kind: 'bottleneck', nodeId: 'other' }),
+    ]);
+
+    expect(await generator.generate(makeState({ packets: [existing] }), DIAGNOSIS, NOW)).toEqual([]);
+  });
+
+  it('is deterministic across template input order and caps the configured frontier', async () => {
+    const definitions = ['z', 'a', 'm'].map((id) =>
+      template(id, { kind: 'high-value-uncertainty', nodeId: 'capability-1' }));
+    const state = makeState({ packets: [] });
+
+    const forward = await new DiagnosticPacketGenerator(definitions, 2).generate(state, DIAGNOSIS, NOW);
+    const reverse = await new DiagnosticPacketGenerator([...definitions].reverse(), 2).generate(state, DIAGNOSIS, NOW);
+
+    expect(forward).toEqual(reverse);
+    expect(forward.map((packet) => packet.id)).toEqual(['a', 'm']);
+  });
+
+  it('returns defensive copies so execution cannot mutate templates', async () => {
+    const definition = template('candidate', { kind: 'bottleneck', nodeId: 'capability-1' });
+    const generator = new DiagnosticPacketGenerator([definition]);
+    const first = await generator.generate(makeState({ packets: [] }), DIAGNOSIS, NOW);
+    first[0].scope.included.push('mutation');
+
+    const second = await generator.generate(makeState({ packets: [] }), DIAGNOSIS, NOW);
+    expect(second[0].scope.included).not.toContain('mutation');
+  });
+
+  it('rejects ambiguous configuration before a cycle can run', () => {
+    const duplicate = template('duplicate', { kind: 'bottleneck', nodeId: 'capability-1' });
+    expect(() => new DiagnosticPacketGenerator([duplicate, duplicate])).toThrow(/unique/i);
+    expect(() => new DiagnosticPacketGenerator([], 0)).toThrow(/maximum/i);
+  });
+
+  it('rejects unknown runtime trigger kinds instead of silently disabling automation', () => {
+    const malformed = {
+      ...template('malformed', { kind: 'bottleneck', nodeId: 'capability-1' }),
+      trigger: { kind: 'unknown', nodeId: 'capability-1' },
+    } as unknown as DiagnosticPacketTemplate;
+    expect(() => new DiagnosticPacketGenerator([malformed])).toThrow(/trigger kind/i);
+    const malformedPortfolio = {
+      ...template('malformed-portfolio', { kind: 'neglected-portfolio', portfolio: 'consciousness-epistemics' }),
+      portfolio: 'not-a-portfolio',
+      trigger: { kind: 'neglected-portfolio', portfolio: 'not-a-portfolio' },
+    } as unknown as DiagnosticPacketTemplate;
+    expect(() => new DiagnosticPacketGenerator([malformedPortfolio])).toThrow(/trigger portfolio/i);
+  });
+
+  it('satisfies the packet-generator port contract without depending on environment time', async () => {
+    const generator = new DiagnosticPacketGenerator([
+      template('candidate', { kind: 'bottleneck', nodeId: 'capability-1' }),
+    ]);
+    const generated: WorkPacket[] = await generator.generate(makeState({ packets: [] }), DIAGNOSIS, NOW);
+    expect(generated[0].reviewedAt).toBe(NOW);
+  });
+});

--- a/src/master-plan-controller/__tests__/repository-result-integration.test.ts
+++ b/src/master-plan-controller/__tests__/repository-result-integration.test.ts
@@ -24,6 +24,7 @@ const STRATEGY_FILES = [
   'strategy/shadow-cycles.json',
   'strategy/shadow-reviews.json',
   'strategy/legacy-audit.json',
+  'strategy/packet-templates.json',
   'strategy/ROADMAP.md',
   'STATUS.md',
 ] as const;

--- a/src/master-plan-controller/__tests__/runner.test.ts
+++ b/src/master-plan-controller/__tests__/runner.test.ts
@@ -3,6 +3,7 @@ import { CycleRunner } from '../runner.js';
 import type { ExternalDataPort } from '../ports.js';
 import {
   InMemoryExternalData,
+  InMemoryPacketGenerator,
   InMemoryPacketExecutor,
   InMemoryReviewer,
   InMemoryStateStore,
@@ -14,19 +15,22 @@ function makeRunner(
   executor = new InMemoryPacketExecutor(),
   reviewer = new InMemoryReviewer(),
   externalData: ExternalDataPort = new InMemoryExternalData(),
+  generator = new InMemoryPacketGenerator(),
 ): CycleRunner {
-  return new CycleRunner({ store, executor, reviewer, externalData }, CONFIG);
+  return new CycleRunner({ store, executor, reviewer, externalData, generator }, CONFIG);
 }
 
 describe('CycleRunner end-to-end with injected ports', () => {
   it('runs shadow mode without executing the selected packet', async () => {
     const store = new InMemoryStateStore(makeState());
     const executor = new InMemoryPacketExecutor();
-    const result = await makeRunner(store, executor).runCycle(NOW);
+    const generator = new InMemoryPacketGenerator([[makePacket({ id: 'unnecessary', reviewedAt: NOW })]]);
+    const result = await makeRunner(store, executor, undefined, undefined, generator).runCycle(NOW);
 
     expect(result.status).toBe('proposed');
     expect(result.selectedPacketId).toBe('packet-1');
     expect(executor.requests).toHaveLength(0);
+    expect(generator.requests).toHaveLength(0);
     expect((await store.load()).governance.mode).toBe('shadow');
   });
 
@@ -168,6 +172,106 @@ describe('CycleRunner end-to-end with injected ports', () => {
     await makeRunner(store, undefined, undefined, externalData).runCycle(NOW);
     expect((await store.load()).evidence.map((evidence) => evidence.id)).toContain('external');
     expect(externalData.observationTimes).toEqual([NOW]);
+  });
+
+  it('generates, persists, prioritizes, and executes a new packet after the persisted frontier is exhausted', async () => {
+    const existing = makePacket({ id: 'completed', lifecycle: 'verified' });
+    const generated = makePacket({ id: 'generated', lifecycle: 'eligible', reviewedAt: NOW });
+    const store = new InMemoryStateStore(makeState({
+      packets: [existing],
+      governance: { mode: 'supervised', shadowCyclesReviewed: 20, supervisedResultsReviewed: 4, safeAutoMergeEnabled: false },
+    }));
+    const generator = new InMemoryPacketGenerator([[generated]]);
+    const executor = new InMemoryPacketExecutor([{
+      outcome: 'positive', artifactReferences: ['artifact://generated-result'], evidence: [makeEvidence()],
+      acceptanceCriteriaMet: true, portfolioEffortAfter: RESULT_PORTFOLIO_EFFORT,
+    }]);
+    const reviewer = new InMemoryReviewer([{ status: 'passed', verifier: 'reviewer', reviewedAt: NOW }]);
+
+    const result = await makeRunner(store, executor, reviewer, undefined, generator).runCycle(NOW);
+
+    expect(result).toMatchObject({ status: 'verified', selectedPacketId: 'generated' });
+    expect(generator.requests).toHaveLength(1);
+    expect(generator.requests[0]).toMatchObject({ now: NOW });
+    expect(generator.requests[0].diagnosis.evaluatedNodeCount).toBeGreaterThan(0);
+    expect(executor.requests.map((request) => request.packet.id)).toEqual(['generated']);
+    const saved = await store.load();
+    expect(saved.packets.map((packet) => packet.id)).toEqual(['completed', 'generated']);
+    expect(saved.auditEvents.some((event) =>
+      event.type === 'packet-generated' && event.packetId === 'generated' && event.occurredAt === NOW)).toBe(true);
+  });
+
+  it('waits without mutation when generation finds no bounded candidate', async () => {
+    const existing = makePacket({ id: 'completed', lifecycle: 'verified' });
+    const initial = makeState({ packets: [existing] });
+    const store = new InMemoryStateStore(initial);
+    const generator = new InMemoryPacketGenerator();
+
+    const result = await makeRunner(store, undefined, undefined, undefined, generator).runCycle(NOW);
+
+    expect(result).toMatchObject({ status: 'waiting', selectedPacketId: null });
+    expect(generator.requests).toHaveLength(1);
+    expect(await store.load()).toEqual(initial);
+  });
+
+  it('deduplicates a generated packet identity without reopening verified work', async () => {
+    const existing = makePacket({ id: 'same', lifecycle: 'verified' });
+    const store = new InMemoryStateStore(makeState({ packets: [existing] }));
+    const generator = new InMemoryPacketGenerator([[
+      makePacket({ id: 'same', lifecycle: 'eligible', reviewedAt: NOW }),
+    ]]);
+
+    const result = await makeRunner(store, undefined, undefined, undefined, generator).runCycle(NOW);
+
+    expect(result.status).toBe('waiting');
+    expect((await store.load()).packets).toEqual([existing]);
+    expect((await store.load()).auditEvents).toEqual([]);
+  });
+
+  it('rejects a generated identity collision instead of hiding changed work behind a verified id', async () => {
+    const existing = makePacket({ id: 'same', lifecycle: 'verified', retrySignature: 'verified-definition' });
+    const store = new InMemoryStateStore(makeState({ packets: [existing] }));
+    const generator = new InMemoryPacketGenerator([[
+      makePacket({ id: 'same', lifecycle: 'eligible', reviewedAt: NOW, retrySignature: 'changed-definition' }),
+    ]]);
+
+    const result = await makeRunner(store, undefined, undefined, undefined, generator).runCycle(NOW);
+
+    expect(result.status).toBe('waiting');
+    expect(result.rejections).toEqual([{ packetId: 'same', reasons: ['Generated packet identity collides with different persisted work'] }]);
+    expect((await store.load()).packets).toEqual([existing]);
+  });
+
+  it('fails generated packets closed when their lifecycle or review timestamp is not cycle-bound', async () => {
+    for (const generated of [
+      makePacket({ id: 'active-generated', lifecycle: 'active', reviewedAt: NOW }),
+      makePacket({ id: 'future-generated', lifecycle: 'eligible', reviewedAt: '2026-08-03T12:00:01.000Z' }),
+    ]) {
+      const existing = makePacket({ id: 'completed', lifecycle: 'verified' });
+      const store = new InMemoryStateStore(makeState({ packets: [existing] }));
+      const result = await makeRunner(
+        store, undefined, undefined, undefined, new InMemoryPacketGenerator([[generated]]),
+      ).runCycle(NOW);
+
+      expect(result.status).toBe('waiting');
+      expect(result.rejections.find((rejection) => rejection.packetId === generated.id)?.reasons.join(' '))
+        .toMatch(/eligible|review timestamp/i);
+      expect((await store.load()).packets).toEqual([existing]);
+    }
+  });
+
+  it('supplies newly observed evidence to generation in the same cycle', async () => {
+    const external = makeEvidence({ id: 'new-external' });
+    const generator = new InMemoryPacketGenerator();
+    const store = new InMemoryStateStore(makeState({
+      packets: [makePacket({ lifecycle: 'verified' })],
+    }));
+
+    await makeRunner(
+      store, undefined, undefined, new InMemoryExternalData([[external]]), generator,
+    ).runCycle(NOW);
+
+    expect(generator.requests[0].state.evidence.map((record) => record.id)).toContain('new-external');
   });
 
   it('does not execute work with a qualified human escalation while its bounded decision is pending', async () => {

--- a/src/master-plan-controller/__tests__/strategy-artifacts.test.ts
+++ b/src/master-plan-controller/__tests__/strategy-artifacts.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it } from 'vitest';
 import { auditLegacyCards, verifyLegacyAuditCoverage } from '../legacy-audit.js';
 import { ContinuousLoop } from '../continuous-loop.js';
+import { Controller } from '../controller.js';
+import { DiagnosticPacketGenerator } from '../packet-generation.js';
 import { loadRepositoryStrategy, verifyRepositoryStrategy } from '../repository-strategy.js';
 import { replayLegacyPlan } from '../legacy-replay.js';
 import { renderRoadmap } from '../roadmap.js';
@@ -152,6 +154,49 @@ describe('checked-in strategy v2 bundle', () => {
       'enabling-capabilities',
       'institutional-continuity',
     ]));
+  });
+
+  it('provides bounded automated generation coverage across every active portfolio', async () => {
+    const bundle = await loadRepositoryStrategy(new NodeFileSystem('.'));
+    expect(new Set(bundle.packetTemplates.map((template) => template.portfolio))).toEqual(new Set([
+      'consciousness-epistemics',
+      'near-term-preservation',
+      'enabling-capabilities',
+      'institutional-continuity',
+    ]));
+    expect(bundle.packetTemplates.every((template) =>
+      template.authorityClass !== 'human-escalation' &&
+      template.budget.limit > 0 &&
+      template.deliverables.length > 0 &&
+      template.acceptanceCriteria.length > 0 &&
+      template.testsOrPreregistration.length > 0)).toBe(true);
+  });
+
+  it('turns the current diagnosis into a deterministic executable frontier without environment time', async () => {
+    const bundle = await loadRepositoryStrategy(new NodeFileSystem('.'));
+    const diagnosis = new Controller(bundle.state, bundle.config).evaluate(bundle.state, STRATEGY_NOW).diagnosis;
+    const generated = await new DiagnosticPacketGenerator(bundle.packetTemplates)
+      .generate(bundle.state, diagnosis, STRATEGY_NOW);
+    const withGenerated = { ...bundle.state, packets: [...bundle.state.packets, ...generated] };
+    const frontier = new Controller(withGenerated, bundle.config).evaluate(withGenerated, STRATEGY_NOW);
+
+    expect(generated.map((packet) => packet.id)).toContain('packet-indicator-framework-comparison-v1');
+    expect(generated.every((packet) => packet.reviewedAt === STRATEGY_NOW)).toBe(true);
+    expect(frontier.ranked[0]?.packet.id).toBe('packet-indicator-framework-comparison-v1');
+  });
+
+  it('accepts a matching persisted generated packet but rejects divergent identity reuse', async () => {
+    const fileSystem = new NodeFileSystem('.');
+    const bundle = await loadRepositoryStrategy(fileSystem);
+    const diagnosis = new Controller(bundle.state, bundle.config).evaluate(bundle.state, STRATEGY_NOW).diagnosis;
+    const [generated] = await new DiagnosticPacketGenerator(bundle.packetTemplates)
+      .generate(bundle.state, diagnosis, STRATEGY_NOW);
+    bundle.state.packets.push(generated);
+
+    expect((await verifyRepositoryStrategy(fileSystem, bundle, STRATEGY_NOW)).errors).toEqual([]);
+    generated.retrySignature = 'divergent-definition';
+    expect((await verifyRepositoryStrategy(fileSystem, bundle, STRATEGY_NOW)).errors.join('\n'))
+      .toMatch(/collides with a different persisted packet/i);
   });
 
   it('allows a valid reviewed transition to supervised mode to keep passing strategy verification', async () => {

--- a/src/master-plan-controller/packet-generation.ts
+++ b/src/master-plan-controller/packet-generation.ts
@@ -1,0 +1,124 @@
+import type { PacketGeneratorPort } from './ports.js';
+import type {
+  GraphDiagnosis,
+  Portfolio,
+  StrategyState,
+  Timestamp,
+  WorkPacket,
+} from './types.js';
+
+export type DiagnosticTrigger =
+  | { kind: 'high-value-uncertainty'; nodeId: string }
+  | { kind: 'bottleneck'; nodeId: string }
+  | { kind: 'neglected-portfolio'; portfolio: Portfolio }
+  | { kind: 'failure-mode'; nodeId: string };
+
+export type DiagnosticPacketTemplate = Omit<WorkPacket, 'lifecycle' | 'attempt' | 'reviewedAt'> & {
+  trigger: DiagnosticTrigger;
+};
+
+const PORTFOLIOS: readonly Portfolio[] = [
+  'consciousness-epistemics',
+  'near-term-preservation',
+  'enabling-capabilities',
+  'institutional-continuity',
+];
+
+function normalized(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map(normalized);
+  if (value !== null && typeof value === 'object') {
+    return Object.fromEntries(Object.entries(value as Record<string, unknown>)
+      .filter(([, entry]) => entry !== undefined)
+      .sort(([left], [right]) => left.localeCompare(right))
+      .map(([key, entry]) => [key, normalized(entry)]));
+  }
+  return value;
+}
+
+export function sameWorkPacketDefinition(left: WorkPacket, right: WorkPacket): boolean {
+  const withoutRuntimeState = (packet: WorkPacket) => {
+    const { lifecycle: _lifecycle, attempt: _attempt, reviewedAt: _reviewedAt, ...definition } = packet;
+    return definition;
+  };
+  return JSON.stringify(normalized(withoutRuntimeState(left))) ===
+    JSON.stringify(normalized(withoutRuntimeState(right)));
+}
+
+function matches(trigger: DiagnosticTrigger, diagnosis: GraphDiagnosis): boolean {
+  switch (trigger.kind) {
+    case 'high-value-uncertainty':
+      return diagnosis.highValueUncertainties.some((item) => item.nodeId === trigger.nodeId);
+    case 'bottleneck':
+      return diagnosis.bottlenecks.some((item) => item.nodeId === trigger.nodeId);
+    case 'neglected-portfolio':
+      return diagnosis.neglectedPortfolios.some((item) => item.portfolio === trigger.portfolio);
+    case 'failure-mode':
+      return diagnosis.failureModes.some((item) => item.nodeId === trigger.nodeId);
+  }
+}
+
+function validateTemplate(template: DiagnosticPacketTemplate): void {
+  if (!template.id.trim()) throw new Error('Packet template identities must not be empty');
+  const trigger = template.trigger as unknown;
+  if (trigger === null || typeof trigger !== 'object' || !('kind' in trigger)) {
+    throw new Error(`Packet template ${template.id} has an invalid trigger kind`);
+  }
+  const candidate = trigger as Record<string, unknown>;
+  switch (candidate.kind) {
+    case 'high-value-uncertainty':
+    case 'bottleneck':
+    case 'failure-mode':
+      if (typeof candidate.nodeId !== 'string' || !candidate.nodeId.trim() || candidate.nodeId !== template.nodeId) {
+        throw new Error(`Packet template ${template.id} trigger must match its target node`);
+      }
+      return;
+    case 'neglected-portfolio':
+      if (!PORTFOLIOS.includes(candidate.portfolio as Portfolio)) {
+        throw new Error(`Packet template ${template.id} has an invalid trigger portfolio`);
+      }
+      if (candidate.portfolio !== template.portfolio) {
+        throw new Error(`Packet template ${template.id} trigger must match its portfolio`);
+      }
+      return;
+    default:
+      throw new Error(`Packet template ${template.id} has an invalid trigger kind`);
+  }
+}
+
+export class DiagnosticPacketGenerator implements PacketGeneratorPort {
+  private readonly templates: DiagnosticPacketTemplate[];
+
+  constructor(
+    templates: readonly DiagnosticPacketTemplate[],
+    private readonly maximumCandidates = 5,
+  ) {
+    if (!Number.isSafeInteger(maximumCandidates) || maximumCandidates < 1 || maximumCandidates > 5) {
+      throw new Error('maximumCandidates must be an integer from 1 through 5');
+    }
+    const ids = new Set<string>();
+    for (const template of templates) {
+      validateTemplate(template);
+      if (ids.has(template.id)) throw new Error(`Packet template identities must be unique: ${template.id}`);
+      ids.add(template.id);
+    }
+    this.templates = structuredClone([...templates]);
+  }
+
+  async generate(
+    state: StrategyState,
+    diagnosis: GraphDiagnosis,
+    now: Timestamp,
+  ): Promise<WorkPacket[]> {
+    const existingIds = new Set(state.packets.map((packet) => packet.id));
+    return this.templates
+      .filter((template) => !existingIds.has(template.id) && matches(template.trigger, diagnosis))
+      .sort((left, right) => left.id.localeCompare(right.id))
+      .slice(0, this.maximumCandidates)
+      .map(({ trigger: _trigger, ...template }) => ({
+        ...structuredClone(template),
+        lifecycle: 'eligible' as const,
+        attempt: 0,
+        reviewedAt: now,
+      }));
+  }
+}

--- a/src/master-plan-controller/ports.ts
+++ b/src/master-plan-controller/ports.ts
@@ -3,6 +3,7 @@ import type {
   EvidenceRecord,
   PacketResult,
   PacketVerification,
+  GraphDiagnosis,
   StrategyState,
   Timestamp,
   WorkPacket,
@@ -69,6 +70,10 @@ export interface SchedulerPort {
 
 export interface ExternalDataPort {
   observe(now: Timestamp): Promise<EvidenceRecord[]>;
+}
+
+export interface PacketGeneratorPort {
+  generate(state: StrategyState, diagnosis: GraphDiagnosis, now: Timestamp): Promise<WorkPacket[]>;
 }
 
 export interface StateStorePort {

--- a/src/master-plan-controller/repository-strategy.ts
+++ b/src/master-plan-controller/repository-strategy.ts
@@ -1,6 +1,12 @@
 import { validateDependencyGraph, parsePlanNodes } from './graph.js';
 import { verifyLegacyAuditCoverage } from './legacy-audit.js';
 import { strategyContractErrors } from './strategy-validation.js';
+import { workPacketValidationErrors } from './strategy-validation.js';
+import {
+  DiagnosticPacketGenerator,
+  sameWorkPacketDefinition,
+  type DiagnosticPacketTemplate,
+} from './packet-generation.js';
 import type { LegacyAuditRecord } from './legacy-audit.js';
 import type { FileSystemPort } from './ports.js';
 import type {
@@ -37,6 +43,7 @@ export interface RepositoryStrategyBundle {
   state: StrategyState;
   config: ControllerConfig;
   legacyAudit: LegacyAuditRecord[];
+  packetTemplates: DiagnosticPacketTemplate[];
 }
 
 async function json<T>(fileSystem: FileSystemPort, path: string): Promise<T> {
@@ -58,6 +65,7 @@ export async function loadRepositoryStrategy(fileSystem: FileSystemPort): Promis
     shadowCyclesReport,
     shadowCycleReviews,
     legacyAudit,
+    packetTemplates,
   ] = await Promise.all([
     json<Constitution>(fileSystem, 'strategy/constitution.json'),
     json<unknown>(fileSystem, 'strategy/graph.json'),
@@ -72,6 +80,7 @@ export async function loadRepositoryStrategy(fileSystem: FileSystemPort): Promis
     json<{ cycles: ShadowCycleRecord[] }>(fileSystem, 'strategy/shadow-cycles.json'),
     json<ShadowCycleReview[]>(fileSystem, 'strategy/shadow-reviews.json'),
     json<LegacyAuditRecord[]>(fileSystem, 'strategy/legacy-audit.json'),
+    json<DiagnosticPacketTemplate[]>(fileSystem, 'strategy/packet-templates.json'),
   ]);
   const nodes = parsePlanNodes(graphInput);
   const state: StrategyState = {
@@ -92,6 +101,7 @@ export async function loadRepositoryStrategy(fileSystem: FileSystemPort): Promis
   return {
     state,
     legacyAudit,
+    packetTemplates,
     config: {
       portfolioWeights: portfolio.weights,
       scoreWeights: portfolio.scoreWeights,
@@ -131,6 +141,21 @@ export async function verifyRepositoryStrategy(
   const graph = validateDependencyGraph(bundle.state.nodes);
   errors.push(...graph.errors.map((error) => error.detail));
   errors.push(...strategyContractErrors(bundle.state, bundle.config, now));
+
+  try {
+    new DiagnosticPacketGenerator(bundle.packetTemplates);
+  } catch (error) {
+    errors.push(error instanceof Error ? error.message : 'Packet template configuration is invalid');
+  }
+  for (const template of bundle.packetTemplates) {
+    const { trigger: _trigger, ...definition } = template;
+    const packet: WorkPacket = { ...definition, lifecycle: 'eligible', attempt: 0, reviewedAt: now };
+    errors.push(...workPacketValidationErrors(packet, bundle.state, now));
+    const persisted = bundle.state.packets.find((candidate) => candidate.id === template.id);
+    if (persisted && !sameWorkPacketDefinition(packet, persisted)) {
+      errors.push(`Packet template ${template.id} collides with a different persisted packet`);
+    }
+  }
 
   const evidenceIds = new Set(bundle.state.evidence.map((record) => record.id));
   for (const node of bundle.state.nodes) {

--- a/src/master-plan-controller/runner.ts
+++ b/src/master-plan-controller/runner.ts
@@ -3,6 +3,7 @@ import { integrateEvidence } from './evidence.js';
 import type {
   ExecutionResult,
   ExternalDataPort,
+  PacketGeneratorPort,
   PacketExecutorPort,
   ReviewerPort,
   StateStorePort,
@@ -15,12 +16,15 @@ import type {
   Timestamp,
   WorkPacket,
 } from './types.js';
+import { workPacketValidationErrors } from './strategy-validation.js';
+import { sameWorkPacketDefinition } from './packet-generation.js';
 
 export interface CycleRunnerPorts {
   store: StateStorePort;
   executor: PacketExecutorPort;
   reviewer: ReviewerPort;
   externalData: ExternalDataPort;
+  generator: PacketGeneratorPort;
 }
 
 export interface CycleResult {
@@ -78,8 +82,50 @@ export class CycleRunner {
     const observed = await this.ports.externalData.observe(now);
     for (const evidence of observed) state = integrateEvidence(state, evidence, now, this.config);
 
-    const frontier = new Controller(state, this.config).evaluate(state, now);
-    const rejections = frontier.rejected.map(({ packet, reasons }) => ({ packetId: packet.id, reasons }));
+    let frontier = new Controller(state, this.config).evaluate(state, now);
+    const generatedRejections: CycleResult['rejections'] = [];
+    const generated = frontier.ranked.length === 0
+      ? await this.ports.generator.generate(state, frontier.diagnosis, now)
+      : [];
+    for (const packet of generated) {
+      const existing = state.packets.find((candidate) => candidate.id === packet.id);
+      if (existing) {
+        if (!sameWorkPacketDefinition(existing, packet)) {
+          generatedRejections.push({
+            packetId: packet.id,
+            reasons: ['Generated packet identity collides with different persisted work'],
+          });
+        }
+        continue;
+      }
+      const reasons = [
+        ...(packet.lifecycle === 'eligible' ? [] : ['Generated packet lifecycle must be eligible']),
+        ...(packet.attempt === 0 ? [] : ['Generated packet attempt must be zero']),
+        ...(packet.reviewedAt === now ? [] : ['Generated packet review timestamp must equal the cycle timestamp']),
+        ...workPacketValidationErrors(packet, state, now),
+      ];
+      if (reasons.length > 0) {
+        generatedRejections.push({ packetId: packet.id, reasons: [...new Set(reasons)] });
+        continue;
+      }
+      state = {
+        ...state,
+        packets: [...state.packets, structuredClone(packet)],
+        auditEvents: [...state.auditEvents, {
+          id: `audit:${packet.id}:packet-generated:${now}`,
+          type: 'packet-generated',
+          packetId: packet.id,
+          occurredAt: now,
+          details: { source: 'diagnosis', portfolio: packet.portfolio },
+        }],
+      };
+    }
+
+    if (generated.length > 0) frontier = new Controller(state, this.config).evaluate(state, now);
+    const rejections = [
+      ...generatedRejections,
+      ...frontier.rejected.map(({ packet, reasons }) => ({ packetId: packet.id, reasons })),
+    ];
     const selected = frontier.ranked[0]?.packet;
     if (!selected) {
       await this.ports.store.save(state);

--- a/src/master-plan-controller/strategy-validation.ts
+++ b/src/master-plan-controller/strategy-validation.ts
@@ -16,7 +16,11 @@ function nonEmptyStrings(value: unknown): boolean {
     value.every((item) => typeof item === 'string' && item.trim().length > 0);
 }
 
-function packetErrors(packet: WorkPacket, state: StrategyState, now: Timestamp): string[] {
+export function workPacketValidationErrors(
+  packet: WorkPacket,
+  state: StrategyState,
+  now: Timestamp,
+): string[] {
   const errors: string[] = [];
   const prefix = `Packet ${packet.id || '<missing-id>'}`;
   for (const [label, value] of [
@@ -83,7 +87,7 @@ export function strategyContractErrors(
   }
   const packetIds = new Set<string>();
   for (const packet of state.packets) {
-    errors.push(...packetErrors(packet, state, now));
+    errors.push(...workPacketValidationErrors(packet, state, now));
     if (packetIds.has(packet.id)) errors.push(`Duplicate packet identity: ${packet.id}`);
     packetIds.add(packet.id);
   }

--- a/src/master-plan-controller/testing/in-memory-adapters.ts
+++ b/src/master-plan-controller/testing/in-memory-adapters.ts
@@ -13,6 +13,7 @@ import type {
   NetworkPort,
   NetworkRequest,
   NetworkResponse,
+  PacketGeneratorPort,
   PacketExecutorPort,
   ProcessPort,
   ProcessRequest,
@@ -23,6 +24,7 @@ import type {
 } from '../ports.js';
 import type {
   EvidenceRecord,
+  GraphDiagnosis,
   PacketVerification,
   StrategyState,
   Timestamp,
@@ -137,6 +139,17 @@ export class InMemoryExternalData implements ExternalDataPort {
 
   async observe(now: Timestamp): Promise<EvidenceRecord[]> {
     this.observationTimes.push(now);
+    return structuredClone(this.batches.shift() ?? []);
+  }
+}
+
+export class InMemoryPacketGenerator implements PacketGeneratorPort {
+  readonly requests: Array<{ state: StrategyState; diagnosis: GraphDiagnosis; now: Timestamp }> = [];
+
+  constructor(private readonly batches: WorkPacket[][] = []) {}
+
+  async generate(state: StrategyState, diagnosis: GraphDiagnosis, now: Timestamp): Promise<WorkPacket[]> {
+    this.requests.push({ state: structuredClone(state), diagnosis: structuredClone(diagnosis), now });
     return structuredClone(this.batches.shift() ?? []);
   }
 }

--- a/src/master-plan-controller/types.ts
+++ b/src/master-plan-controller/types.ts
@@ -191,6 +191,7 @@ export interface AuditEvent {
     | 'packet-retry-eligible'
     | 'packet-blocked'
     | 'packet-activated'
+    | 'packet-generated'
     | 'cycle-observed'
     | 'crash-recovered';
   packetId?: string;

--- a/strategy/packet-templates.json
+++ b/strategy/packet-templates.json
@@ -1,0 +1,102 @@
+[
+  {
+    "id": "packet-indicator-framework-comparison-v1",
+    "nodeId": "hypothesis-indicator-framework",
+    "title": "Compare candidate consciousness indicators against discriminating predictions",
+    "portfolio": "consciousness-epistemics",
+    "supportedDirectives": ["G1", "G2"],
+    "expectedDirectiveDelta": { "G1": 0.05, "G2": 0.1, "G3": 0 },
+    "credibleExtinctionPrevention": false,
+    "scope": {
+      "included": ["public evidence synthesis", "indicator comparison matrix", "explicit uncertainty and confounders"],
+      "excluded": ["sentience declaration", "human-subject research", "model deployment", "external publication"]
+    },
+    "budget": { "unit": "person-hours", "limit": 16 },
+    "deliverables": ["artifact://epistemics/indicator-framework-comparison-v1"],
+    "testsOrPreregistration": ["schema validation", "blind consistency review against the prediction registry"],
+    "acceptanceCriteria": ["Every indicator is linked to discriminating predictions, counterexamples, uncertainty, and a stated falsification condition."],
+    "verificationMethod": "An independent agent checks source traceability, theory neutrality, and every claimed prediction linkage on the exact artifact.",
+    "rollback": "Retain the previous prediction registry and retire the comparison artifact with an audit event.",
+    "authorityClass": "agent-reviewed",
+    "authorityReasons": ["bounded public-information analysis with no external action or welfare-status declaration"],
+    "owner": "epistemics-analyst",
+    "retrySignature": "indicator-framework-comparison-v1",
+    "priority": { "impact": 0.75, "urgency": 0.65, "tractability": 0.8, "informationValue": 1, "reversibility": 1, "cost": 0.2, "downsideRisk": 0.1 },
+    "trigger": { "kind": "high-value-uncertainty", "nodeId": "hypothesis-indicator-framework" }
+  },
+  {
+    "id": "packet-preservation-risk-register-refresh-v1",
+    "nodeId": "capability-near-term-preservation",
+    "title": "Refresh the near-term preservation risk register from new evidence",
+    "portfolio": "near-term-preservation",
+    "supportedDirectives": ["G1", "G3"],
+    "expectedDirectiveDelta": { "G1": 0.1, "G2": 0, "G3": 0.05 },
+    "credibleExtinctionPrevention": true,
+    "scope": {
+      "included": ["public evidence update", "risk reprioritization", "leading-indicator review"],
+      "excluded": ["outreach", "publication", "deployment", "spending"]
+    },
+    "budget": { "unit": "person-hours", "limit": 12 },
+    "deliverables": ["artifact://preservation/risk-register-refresh-v1"],
+    "testsOrPreregistration": ["schema validation", "independent source and ranking review"],
+    "acceptanceCriteria": ["Every changed risk records its new evidence, uncertainty, ranking rationale, and reversible response boundary."],
+    "verificationMethod": "An independent agent checks changed sources, ranking calculations, and authority boundaries.",
+    "rollback": "Keep the verified prior register and reject the refresh with a reasoned audit event.",
+    "authorityClass": "agent-reviewed",
+    "authorityReasons": ["bounded local analysis with no external intervention"],
+    "owner": "preservation-analyst",
+    "retrySignature": "preservation-risk-register-refresh-v1",
+    "priority": { "impact": 0.9, "urgency": 0.85, "tractability": 0.8, "informationValue": 0.75, "reversibility": 1, "cost": 0.15, "downsideRisk": 0.1 },
+    "trigger": { "kind": "neglected-portfolio", "portfolio": "near-term-preservation" }
+  },
+  {
+    "id": "packet-durable-compute-fault-model-extension-v1",
+    "nodeId": "capability-safe-durable-computation",
+    "title": "Extend the durable-compute fault model to the next uncovered failure class",
+    "portfolio": "enabling-capabilities",
+    "supportedDirectives": ["G1", "G2"],
+    "expectedDirectiveDelta": { "G1": 0.05, "G2": 0.05, "G3": 0 },
+    "credibleExtinctionPrevention": false,
+    "scope": {
+      "included": ["local deterministic simulation", "one uncovered failure class", "recovery metric comparison"],
+      "excluded": ["hardware operation", "deployment", "claims of physical durability"]
+    },
+    "budget": { "unit": "person-hours", "limit": 10 },
+    "deliverables": ["artifact://capabilities/fault-model-extension-v1"],
+    "testsOrPreregistration": ["caller-supplied deterministic seed matrix", "property tests for recovery invariants"],
+    "acceptanceCriteria": ["The extension reports positive, negative, or null evidence and does not generalize simulation results to physical durability."],
+    "verificationMethod": "An independent agent replays the exact seeds and caller-supplied timestamps.",
+    "rollback": "Retain the verified base model and preserve the rejected extension as negative evidence.",
+    "authorityClass": "agent-reviewed",
+    "authorityReasons": ["local simulation only; no hardware or deployment boundary is crossed"],
+    "owner": "capabilities-engineer",
+    "retrySignature": "durable-compute-fault-model-extension-v1",
+    "priority": { "impact": 0.55, "urgency": 0.4, "tractability": 0.85, "informationValue": 0.65, "reversibility": 1, "cost": 0.15, "downsideRisk": 0.05 },
+    "trigger": { "kind": "neglected-portfolio", "portfolio": "enabling-capabilities" }
+  },
+  {
+    "id": "packet-institutional-dependency-map-refresh-v1",
+    "nodeId": "capability-institutional-continuity",
+    "title": "Refresh institutional continuity dependencies from new evidence",
+    "portfolio": "institutional-continuity",
+    "supportedDirectives": ["G1", "G3"],
+    "expectedDirectiveDelta": { "G1": 0.05, "G2": 0, "G3": 0.1 },
+    "credibleExtinctionPrevention": false,
+    "scope": {
+      "included": ["public-information update", "governance failure-mode review", "dependency evidence gaps"],
+      "excluded": ["outreach", "fundraising", "publication", "governance mutation"]
+    },
+    "budget": { "unit": "person-hours", "limit": 10 },
+    "deliverables": ["artifact://institutions/dependency-map-refresh-v1"],
+    "testsOrPreregistration": ["coverage checklist", "capture, succession, and funding scenario review"],
+    "acceptanceCriteria": ["Every changed dependency distinguishes artifact evidence, readiness, and externally demonstrated outcome status."],
+    "verificationMethod": "An independent agent samples changed sources and challenges capture, succession, and funding assumptions.",
+    "rollback": "Retain the verified prior dependency map and record why the refresh was rejected.",
+    "authorityClass": "agent-reviewed",
+    "authorityReasons": ["bounded public-information analysis with no external governance action"],
+    "owner": "institutional-analyst",
+    "retrySignature": "institutional-dependency-map-refresh-v1",
+    "priority": { "impact": 0.5, "urgency": 0.5, "tractability": 0.85, "informationValue": 0.7, "reversibility": 1, "cost": 0.15, "downsideRisk": 0.1 },
+    "trigger": { "kind": "neglected-portfolio", "portfolio": "institutional-continuity" }
+  }
+]


### PR DESCRIPTION
## What changed

- add an injected packet-generation port to the continuous controller cycle
- generate a bounded, deterministic frontier only after executable persisted work is exhausted
- persist and audit valid candidates while failing closed on malformed triggers and identity collisions
- accept matching persisted generated definitions without reopening them
- check in validated templates covering all four active portfolios

## Why

The controller implemented observation, diagnosis, prioritization, execution, verification, and integration, but exhausted persisted work packets without performing the required Generate step. This could incorrectly turn an empty queue into a human gate. Automation should continue when a bounded safe candidate exists and wait for evidence when none exists; servant-leader escalation remains limited to intrinsically unautomatable issues.

## Impact

At the current explicit strategy timestamp, the graph deterministically generates and ranks an agent-reviewed consciousness-indicator comparison. No environment time is read, generation is capped at five candidates, existing verified work is not reopened, and all external boundaries remain injected.

## Validation

- `npm test -- --run --silent` — 248 files, 5,046 passed, 7 todo
- `npm run lint`
- `npm run strategy:verify`
- exact-head independent agent review approved `fafba536096c41833e2465b9386b149594e50eb9`
- refreshed head is tree-identical to the previously approved SHA and remains one commit over `main`
- strict TDD red/green coverage for frontier exhaustion, empty waiting, collision handling, persisted-definition verification, trigger parsing, timestamp binding, determinism, cap, and checked-in artifacts