### PR TITLE
Fix auto-merge review provenance

### DIFF
--- a/.github/workflows/safe-auto-merge-request.yml
+++ b/.github/workflows/safe-auto-merge-request.yml
@@ -71,9 +71,8 @@ jobs:
             [.[] | select(.name == "agent-review" and .conclusion == "success")]
             | max_by(.completed_at)
           ' <<<"$checks_json")"
-          agent_details_url="$(jq -r '.details_url' <<<"$agent_check")"
           agent_external_id="$(jq -r '.external_id' <<<"$agent_check")"
-          agent_run_id="$(sed -nE 's#^.*/actions/runs/([0-9]+).*$#\1#p' <<<"$agent_details_url")"
+          agent_run_id="$(sed -nE 's#^agent-review:pr:[0-9]+:head:[0-9a-f]+:run:([0-9]+)$#\1#p' <<<"$agent_external_id")"
           test -n "$agent_run_id"
           test "$agent_external_id" = "agent-review:pr:${pr_number}:head:${HEAD_SHA}:run:${agent_run_id}"
           agent_run="$(gh api "repos/${GITHUB_REPOSITORY}/actions/runs/${agent_run_id}")"

--- a/src/master-plan-controller/__tests__/workflow-governance.test.ts
+++ b/src/master-plan-controller/__tests__/workflow-governance.test.ts
@@ -102,6 +102,10 @@ describe('blocking CI and governed workflows', () => {
     expect(mergeRequest).toContain('agent_controlled_candidate');
     expect(mergeRequest).toContain('.github/workflows/agent-review.yml');
     expect(mergeRequest).toContain('.pull_requests');
+    expect(mergeRequest).toContain('agent_run_id="$(sed');
+    expect(mergeRequest).toContain('<<<"$agent_external_id")"');
+    expect(mergeRequest).not.toContain('agent_details_url=');
+    expect(mergeRequest).not.toContain('<<<"$agent_details_url"');
     for (const protectedPattern of ['network', 'security', 'deploy']) {
       expect(mergeRequest).toContain(protectedPattern);
     }


### PR DESCRIPTION
## What changed

- derive the trusted agent-review workflow run ID from the structured `external_id`
- stop treating GitHub-normalized check `details_url` values as Actions run URLs
- add governance regression assertions that forbid the broken parser

## Root cause

GitHub normalizes the custom check `details_url` to `/runs/<check-or-job-id>`. The trusted auto-merge workflow parsed that value as an Actions workflow run ID, then failed provenance verification even though every required check had passed. The check `external_id` is already exact-head bound and contains the actual workflow run ID.

## Security impact

This does not weaken provenance. The workflow still validates the full external ID against PR number, immutable head SHA, and parsed run ID, then verifies the referenced run path, title, and event before requesting auto-merge.

## Validation

- strict red/green governance test
- parser verified against PR #126 actual external ID and run `30869297091`
- `npm run lint`
- `npm run strategy:verify`
- `npm test -- --run --silent` — 248 files, 5,046 passed, 7 todo (one unrelated timing flake passed on immediate focused and full rerun)
- protected change isolated to one commit