### PR TITLE
Bind agent review run names

### DIFF
--- a/.github/workflows/agent-review.yml
+++ b/.github/workflows/agent-review.yml
@@ -1,5 +1,5 @@
 name: Agent review
-run-name: Agent review PR #${{ github.event.pull_request.number || inputs.pr_number }} @ ${{ github.event.pull_request.head.sha || inputs.head_sha }}
+run-name: "Agent review PR #${{ github.event.pull_request.number || inputs.pr_number }} @ ${{ github.event.pull_request.head.sha || inputs.head_sha }}"
 
 on:
   pull_request_target:

--- a/src/master-plan-controller/__tests__/workflow-governance.test.ts
+++ b/src/master-plan-controller/__tests__/workflow-governance.test.ts
@@ -110,6 +110,7 @@ describe('blocking CI and governed workflows', () => {
       expect(mergeRequest).toContain(protectedPattern);
     }
     expect(agentReview).toContain("name='agent-review'");
+    expect(agentReview).toContain('run-name: "Agent review PR #${{ github.event.pull_request.number || inputs.pr_number }} @ ${{ github.event.pull_request.head.sha || inputs.head_sha }}"');
     expect(agentReview).toContain('group: agent-review-${{ github.event.pull_request.number || inputs.pr_number }}-${{ github.event.pull_request.head.sha || inputs.head_sha }}');
     expect(agentReview).toContain('cancel-in-progress: false');
     expect(agentReview).toContain('pull_request_target:');


### PR DESCRIPTION
## What changed

- quote the agent-review workflow `run-name` so YAML preserves the PR-number and head-SHA expression
- add a governance regression assertion for the exact quoted title

## Root cause

The unquoted `#` began a YAML comment, so GitHub recorded every run as only `Agent review PR`. The trusted auto-merge verifier requires an exact `Agent review PR #<pr> @ <sha>` title and correctly failed closed.

## Security impact

This restores the intended immutable PR/SHA binding; no provenance or review gate is removed.

## Validation

- strict red/green governance test
- observed GitHub run title confirmed the truncation
- `npm run lint`
- `npm run strategy:verify`
- protected workflow change isolated to one commit