### PR TITLE
Make strategy tests independent of integrated state

### DIFF
--- a/src/master-plan-controller/__tests__/repository-candidate-generation.test.ts
+++ b/src/master-plan-controller/__tests__/repository-candidate-generation.test.ts
@@ -3,8 +3,7 @@ import { runRepositoryCandidateGeneration } from '../repository-candidate-genera
 import { runCandidateGenerationCli } from '../cli/generate-candidates.js';
 import { NodeFileSystem } from '../runtime-adapters.js';
 import { InMemoryFileSystem } from '../testing/in-memory-adapters.js';
-
-const NOW = '2026-08-04T02:10:00.000Z';
+import { advanceTimestamp, nextRepositoryTimestamp } from './repository-test-time.js';
 
 async function repositorySnapshot(): Promise<Record<string, string>> {
   const source = new NodeFileSystem('.');
@@ -32,8 +31,9 @@ describe('repository candidate generation', () => {
   it('persists and audits a deterministic candidate using only the caller timestamp', async () => {
     const initial = await repositorySnapshot();
     const fileSystem = new InMemoryFileSystem(initial);
+    const now = nextRepositoryTimestamp(initial);
 
-    const result = await runRepositoryCandidateGeneration(fileSystem, NOW);
+    const result = await runRepositoryCandidateGeneration(fileSystem, now);
 
     expect(result).toEqual({
       generatedPacketIds: ['packet-indicator-framework-comparison-v1'],
@@ -43,13 +43,13 @@ describe('repository candidate generation', () => {
       id: string; lifecycle: string; reviewedAt: string;
     }>;
     expect(packets.at(-1)).toMatchObject({
-      id: 'packet-indicator-framework-comparison-v1', lifecycle: 'eligible', reviewedAt: NOW,
+      id: 'packet-indicator-framework-comparison-v1', lifecycle: 'eligible', reviewedAt: now,
     });
     const audit = JSON.parse(await fileSystem.readText('strategy/audit-log.json')) as Array<{
       type: string; packetId: string; occurredAt: string;
     }>;
     expect(audit.at(-1)).toMatchObject({
-      type: 'packet-generated', packetId: 'packet-indicator-framework-comparison-v1', occurredAt: NOW,
+      type: 'packet-generated', packetId: 'packet-indicator-framework-comparison-v1', occurredAt: now,
     });
     const originalPacketPrefix = initial['strategy/work-packets.json'].trimEnd().slice(0, -1).trimEnd();
     expect((await fileSystem.readText('strategy/work-packets.json')).slice(0, originalPacketPrefix.length))
@@ -57,12 +57,14 @@ describe('repository candidate generation', () => {
   });
 
   it('is idempotent while executable persisted work exists', async () => {
-    const fileSystem = new InMemoryFileSystem(await repositorySnapshot());
-    await runRepositoryCandidateGeneration(fileSystem, NOW);
+    const initial = await repositorySnapshot();
+    const fileSystem = new InMemoryFileSystem(initial);
+    const now = nextRepositoryTimestamp(initial);
+    await runRepositoryCandidateGeneration(fileSystem, now);
     const packetsAfterFirst = await fileSystem.readText('strategy/work-packets.json');
     const auditAfterFirst = await fileSystem.readText('strategy/audit-log.json');
 
-    const second = await runRepositoryCandidateGeneration(fileSystem, '2026-08-04T02:11:00.000Z');
+    const second = await runRepositoryCandidateGeneration(fileSystem, advanceTimestamp(now));
 
     expect(second).toEqual({ generatedPacketIds: [], selectedPacketId: 'packet-indicator-framework-comparison-v1' });
     expect(await fileSystem.readText('strategy/work-packets.json')).toBe(packetsAfterFirst);
@@ -79,10 +81,11 @@ describe('repository candidate generation', () => {
 
   it('exposes an explicit-timestamp CLI boundary', async () => {
     const fileSystem = new InMemoryFileSystem(await repositorySnapshot());
-    expect(JSON.parse(await runCandidateGenerationCli(fileSystem, [NOW]))).toMatchObject({
+    const now = nextRepositoryTimestamp(await repositorySnapshot());
+    expect(JSON.parse(await runCandidateGenerationCli(fileSystem, [now]))).toMatchObject({
       generatedPacketIds: ['packet-indicator-framework-comparison-v1'],
     });
     await expect(runCandidateGenerationCli(fileSystem, [])).rejects.toThrow(/usage/i);
-    await expect(runCandidateGenerationCli(fileSystem, [NOW, NOW])).rejects.toThrow(/usage/i);
+    await expect(runCandidateGenerationCli(fileSystem, [now, now])).rejects.toThrow(/usage/i);
   });
 });

--- a/src/master-plan-controller/__tests__/repository-packet-execution.test.ts
+++ b/src/master-plan-controller/__tests__/repository-packet-execution.test.ts
@@ -1,13 +1,11 @@
 import { describe, expect, it } from 'vitest';
-import { runRepositoryCandidateGeneration } from '../repository-candidate-generation.js';
 import { executeRepositoryPacket, integrateReviewedRepositoryExecution } from '../repository-packet-execution.js';
 import { runPacketExecutionCli } from '../cli/execute-packet.js';
 import { runReviewedExecutionIntegrationCli } from '../cli/integrate-reviewed-execution.js';
 import { NodeFileSystem } from '../runtime-adapters.js';
 import { InMemoryFileSystem } from '../testing/in-memory-adapters.js';
 import type { FileSystemPort } from '../ports.js';
-
-const NOW = '2026-08-04T03:00:00.000Z';
+import { advanceTimestamp, nextRepositoryTimestamp } from './repository-test-time.js';
 const STRATEGY_FILES = [
   'strategy/constitution.json',
   'strategy/graph.json',
@@ -33,22 +31,26 @@ async function snapshot(source: FileSystemPort): Promise<Record<string, string>>
   return Object.fromEntries(files);
 }
 
-async function executableRepository(): Promise<InMemoryFileSystem> {
+async function executableRepository(): Promise<{ fileSystem: InMemoryFileSystem; now: string }> {
   const source = new NodeFileSystem('.');
-  const fileSystem = new InMemoryFileSystem({
+  const initial: Record<string, string> = {
     ...await snapshot(source),
     'strategy/results/consciousness-prediction-registry-v1.json':
       await source.readText('strategy/results/consciousness-prediction-registry-v1.json'),
-  });
-  await runRepositoryCandidateGeneration(fileSystem, NOW);
-  return fileSystem;
+  };
+  const packets = JSON.parse(initial['strategy/work-packets.json']) as Array<{ id: string; lifecycle: string }>;
+  const executable = packets.find((packet) => packet.id === 'packet-indicator-framework-comparison-v1');
+  if (!executable) throw new Error('Indicator comparison packet fixture is missing');
+  executable.lifecycle = 'eligible';
+  initial['strategy/work-packets.json'] = `${JSON.stringify(packets, null, 2)}\n`;
+  return { fileSystem: new InMemoryFileSystem(initial), now: nextRepositoryTimestamp(initial) };
 }
 
 describe('repository packet execution', () => {
   it('deterministically executes the selected indicator-comparison packet at the supplied timestamp', async () => {
-    const fileSystem = await executableRepository();
+    const { fileSystem, now } = await executableRepository();
 
-    const result = await executeRepositoryPacket(fileSystem, NOW);
+    const result = await executeRepositoryPacket(fileSystem, now);
 
     expect(result).toEqual({
       status: 'executed',
@@ -68,7 +70,7 @@ describe('repository packet execution', () => {
         sourceIds: string[];
       }>;
     };
-    expect(artifact.preparedAt).toBe(NOW);
+    expect(artifact.preparedAt).toBe(now);
     expect(artifact.sourceRegistry).toBe('strategy/results/consciousness-prediction-registry-v1.json');
     expect(artifact.indicators.length).toBeGreaterThan(0);
     for (const indicator of artifact.indicators) {
@@ -86,17 +88,17 @@ describe('repository packet execution', () => {
     };
     expect(execution.verification).toBeUndefined();
     expect(execution.artifactReferences).toContain(result.artifactPath);
-    expect(execution.evidence[0].observedAt).toBe(NOW);
+    expect(execution.evidence[0].observedAt).toBe(now);
     expect(execution.evidence[0].limitations.join(' ')).toMatch(/independent agent review/i);
   });
 
   it('is byte-idempotent after the execution artifacts exist', async () => {
-    const fileSystem = await executableRepository();
-    const first = await executeRepositoryPacket(fileSystem, NOW);
+    const { fileSystem, now } = await executableRepository();
+    const first = await executeRepositoryPacket(fileSystem, now);
     const artifact = await fileSystem.readText(first.artifactPath!);
     const execution = await fileSystem.readText(first.resultPath!);
 
-    const second = await executeRepositoryPacket(fileSystem, '2026-08-04T03:30:00.000Z');
+    const second = await executeRepositoryPacket(fileSystem, advanceTimestamp(now));
 
     expect(second).toEqual({ status: 'already-executed', packetId: first.packetId, artifactPath: first.artifactPath, resultPath: first.resultPath });
     expect(await fileSystem.readText(first.artifactPath!)).toBe(artifact);
@@ -104,7 +106,7 @@ describe('repository packet execution', () => {
   });
 
   it('fails closed without writes when the selected packet has no registered executor', async () => {
-    const fileSystem = await executableRepository();
+    const { fileSystem, now } = await executableRepository();
     const packets = JSON.parse(await fileSystem.readText('strategy/work-packets.json')) as Array<Record<string, unknown>>;
     const selected = packets.find((packet) => packet.id === 'packet-indicator-framework-comparison-v1')!;
     selected.id = 'packet-unsupported';
@@ -112,13 +114,13 @@ describe('repository packet execution', () => {
     await fileSystem.writeText('strategy/work-packets.json', `${JSON.stringify(packets, null, 2)}\n`);
     const before = await fileSystem.listFiles('strategy/results/');
 
-    await expect(executeRepositoryPacket(fileSystem, NOW)).rejects.toThrow(/no executor.*packet-unsupported/i);
+    await expect(executeRepositoryPacket(fileSystem, now)).rejects.toThrow(/no executor.*packet-unsupported/i);
 
     expect(await fileSystem.listFiles('strategy/results/')).toEqual(before);
   });
 
   it('rejects invalid caller timestamps before writing', async () => {
-    const fileSystem = await executableRepository();
+    const { fileSystem } = await executableRepository();
     const before = await fileSystem.listFiles('strategy/results/');
 
     await expect(executeRepositoryPacket(fileSystem, 'invalid')).rejects.toThrow(/timestamp/i);
@@ -127,21 +129,21 @@ describe('repository packet execution', () => {
   });
 
   it('exposes only an explicit timestamp through the injected CLI boundary', async () => {
-    const fileSystem = await executableRepository();
+    const { fileSystem, now } = await executableRepository();
 
-    expect(JSON.parse(await runPacketExecutionCli(fileSystem, [NOW]))).toMatchObject({
+    expect(JSON.parse(await runPacketExecutionCli(fileSystem, [now]))).toMatchObject({
       status: 'executed',
       packetId: 'packet-indicator-framework-comparison-v1',
     });
     await expect(runPacketExecutionCli(fileSystem, [])).rejects.toThrow(/usage.*timestamp/i);
-    await expect(runPacketExecutionCli(fileSystem, [NOW, 'extra'])).rejects.toThrow(/usage.*timestamp/i);
+    await expect(runPacketExecutionCli(fileSystem, [now, 'extra'])).rejects.toThrow(/usage.*timestamp/i);
   });
 
   it('binds an exact-head agent attestation before integrating the reviewed result', async () => {
-    const fileSystem = await executableRepository();
-    const execution = await executeRepositoryPacket(fileSystem, NOW);
-    const reviewedAt = '2026-08-04T03:04:00.000Z';
-    const integratedAt = '2026-08-04T03:05:00.000Z';
+    const { fileSystem, now } = await executableRepository();
+    const execution = await executeRepositoryPacket(fileSystem, now);
+    const reviewedAt = advanceTimestamp(now);
+    const integratedAt = advanceTimestamp(reviewedAt);
 
     const integrated = await integrateReviewedRepositoryExecution(fileSystem, {
       packetId: execution.packetId!,
@@ -168,8 +170,8 @@ describe('repository packet execution', () => {
   });
 
   it('rejects malformed or future review attestations before integration', async () => {
-    const fileSystem = await executableRepository();
-    const execution = await executeRepositoryPacket(fileSystem, NOW);
+    const { fileSystem, now } = await executableRepository();
+    const execution = await executeRepositoryPacket(fileSystem, now);
     const resultBefore = await fileSystem.readText(execution.resultPath!);
 
     await expect(integrateReviewedRepositoryExecution(fileSystem, {
@@ -178,8 +180,8 @@ describe('repository packet execution', () => {
       reviewer: '',
       reviewRunId: 'not-a-run',
       reviewedHeadSha: 'not-a-sha',
-      reviewedAt: '2026-08-04T04:00:00.000Z',
-    }, '2026-08-04T03:05:00.000Z')).rejects.toThrow(/attestation/i);
+      reviewedAt: advanceTimestamp(now, 2),
+    }, advanceTimestamp(now))).rejects.toThrow(/attestation/i);
 
     expect(await fileSystem.readText(execution.resultPath!)).toBe(resultBefore);
     const packets = JSON.parse(await fileSystem.readText('strategy/work-packets.json')) as Array<{ id: string; lifecycle: string }>;
@@ -187,12 +189,13 @@ describe('repository packet execution', () => {
   });
 
   it('accepts explicit review provenance through the injected integration CLI', async () => {
-    const fileSystem = await executableRepository();
-    const execution = await executeRepositoryPacket(fileSystem, NOW);
+    const { fileSystem, now } = await executableRepository();
+    const execution = await executeRepositoryPacket(fileSystem, now);
+    const reviewedAt = advanceTimestamp(now);
+    const integratedAt = advanceTimestamp(reviewedAt);
     const output = await runReviewedExecutionIntegrationCli(fileSystem, [
       execution.packetId!, execution.resultPath!, 'github-hosted-agent-review', '42',
-      'abcdefabcdefabcdefabcdefabcdefabcdefabcd', '2026-08-04T03:04:00.000Z',
-      '2026-08-04T03:05:00.000Z',
+      'abcdefabcdefabcdefabcdefabcdefabcdefabcd', reviewedAt, integratedAt,
     ]);
 
     expect(output).toContain(execution.packetId!);

--- a/src/master-plan-controller/__tests__/repository-test-time.ts
+++ b/src/master-plan-controller/__tests__/repository-test-time.ts
@@ -1,0 +1,21 @@
+const ISO_TIMESTAMP = /\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d{3})?Z/g;
+
+export function nextRepositoryTimestamp(files: Readonly<Record<string, string>>): string {
+  let latest = Number.NEGATIVE_INFINITY;
+  for (const content of Object.values(files)) {
+    for (const match of content.matchAll(ISO_TIMESTAMP)) {
+      const epoch = Date.parse(match[0]);
+      if (!Number.isNaN(epoch)) latest = Math.max(latest, epoch);
+    }
+  }
+  if (!Number.isFinite(latest)) throw new Error('Repository fixture has no timestamp');
+  return new Date(latest + 1).toISOString();
+}
+
+export function advanceTimestamp(timestamp: string, milliseconds = 1): string {
+  const epoch = Date.parse(timestamp);
+  if (Number.isNaN(epoch) || !Number.isFinite(milliseconds) || milliseconds <= 0) {
+    throw new Error('A valid timestamp and positive offset are required');
+  }
+  return new Date(epoch + milliseconds).toISOString();
+}

--- a/src/master-plan-controller/__tests__/strategy-artifacts.test.ts
+++ b/src/master-plan-controller/__tests__/strategy-artifacts.test.ts
@@ -48,6 +48,16 @@ function withoutGeneratedIndicator<T extends { state: {
   return result;
 }
 
+function expectReviewedResultCountIsAuditable(bundle: {
+  state: {
+    governance: { supervisedResultsReviewed: number };
+    auditEvents: Array<{ type: string }>;
+  };
+}): void {
+  const verifiedResults = bundle.state.auditEvents.filter((event) => event.type === 'packet-verified').length;
+  expect(bundle.state.governance.supervisedResultsReviewed).toBe(verifiedResults);
+}
+
 function acceptedShadowReviews(cycles: readonly ShadowCycleRecord[]) {
   return cycles.map((cycle, index) => ({
     cycle: index + 1,
@@ -270,7 +280,8 @@ describe('checked-in strategy v2 bundle', () => {
 
   it('uses explicit source limitations and does not declare current AI systems conscious', async () => {
     const bundle = await loadRepositoryStrategy(new NodeFileSystem('.'));
-    expect(bundle.state.evidence).toHaveLength(7);
+    expect(bundle.state.evidence.length).toBeGreaterThanOrEqual(7);
+    expect(new Set(bundle.state.evidence.map((record) => record.id)).size).toBe(bundle.state.evidence.length);
     expect(bundle.state.evidence.every((record) => record.limitations.length > 0)).toBe(true);
     expect(bundle.state.evidence.find((record) =>
       record.id === 'evidence-preservation-risk-register-v1-reviewed')?.limitations.join(' '))
@@ -434,7 +445,7 @@ describe('supervised preservation risk-register artifact', () => {
       .toEqual(result.evidence[0]);
     expect(bundle.state.packets.find((packet) =>
       packet.id === 'packet-preservation-risk-register')?.lifecycle).toBe('verified');
-    expect(bundle.state.governance.supervisedResultsReviewed).toBe(4);
+    expectReviewedResultCountIsAuditable(bundle);
   });
 });
 
@@ -593,7 +604,7 @@ describe('consciousness prediction registry artifact', () => {
       .toEqual(result.evidence[0]);
     expect(bundle.state.packets.find((packet) =>
       packet.id === 'packet-consciousness-prediction-registry')?.lifecycle).toBe('verified');
-    expect(bundle.state.governance.supervisedResultsReviewed).toBe(4);
+    expectReviewedResultCountIsAuditable(bundle);
   });
 });
 
@@ -745,7 +756,7 @@ describe('institutional dependency map artifact', () => {
       .toEqual(result.evidence[0]);
     expect(bundle.state.packets.find((packet) =>
       packet.id === 'packet-institutional-dependency-map')?.lifecycle).toBe('verified');
-    expect(bundle.state.governance.supervisedResultsReviewed).toBe(4);
+    expectReviewedResultCountIsAuditable(bundle);
   });
 });
 
@@ -784,7 +795,7 @@ describe('durable compute fault-model result integration', () => {
       .toEqual(result.evidence[0]);
     expect(bundle.state.packets.find((packet) =>
       packet.id === 'packet-durable-compute-fault-model')?.lifecycle).toBe('verified');
-    expect(bundle.state.governance.supervisedResultsReviewed).toBe(4);
+    expectReviewedResultCountIsAuditable(bundle);
   });
 });
 


### PR DESCRIPTION
Makes candidate-generation, packet-execution, and strategy-artifact tests derive their timestamps and review counts from repository state instead of freezing pre-integration values. This removes the 16 failures discovered after the reviewed indicator-comparison result was integrated.\n\nVerification on both pre-integration main and the real post-integration state:\n- npm test -- --run --silent (250 files; 5058 passed; 7 todo)\n- npm run lint\n- npm run strategy:verify