### PR TITLE
Automate agent review attestation

### DIFF
--- a/.github/workflows/agent-review.yml
+++ b/.github/workflows/agent-review.yml
@@ -22,6 +22,7 @@ permissions:
   checks: write
   contents: read
   pull-requests: read
+  statuses: write
 
 concurrency:
   group: agent-review-${{ github.event.pull_request.number || inputs.pr_number }}-${{ github.event.pull_request.head.sha || inputs.head_sha }}
@@ -46,12 +47,32 @@ jobs:
           set -euo pipefail
           pr_json="$(gh api "repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}")"
           test "$(jq -r '.head.sha' <<< "$pr_json")" = "$HEAD_SHA"
+          publish_success_attestation() {
+            gh api --method POST "repos/${GITHUB_REPOSITORY}/statuses/${HEAD_SHA}" \
+              -f state='success' -f context='agent-review' \
+              -f description="Exact-head agent review run ${GITHUB_RUN_ID} passed" \
+              -f target_url="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}" \
+              >/dev/null
+          }
+          continue_automated_stewardship() {
+            gh workflow run safe-auto-merge-request.yml --repo "$GITHUB_REPOSITORY" --ref main \
+              -f pr_number="$PR_NUMBER" -f head_sha="$HEAD_SHA"
+            if gh api "repos/${GITHUB_REPOSITORY}/contents/.github/workflows/strategy-integrate-reviewed.yml?ref=main" \
+              >/dev/null 2>&1; then
+              gh workflow run strategy-integrate-reviewed.yml --repo "$GITHUB_REPOSITORY" --ref main \
+                -f pr_number="$PR_NUMBER" -f head_sha="$HEAD_SHA"
+            else
+              echo "Reviewed-result integration is not installed on main yet"
+            fi
+          }
           existing_success="$(gh api \
             "repos/${GITHUB_REPOSITORY}/commits/${HEAD_SHA}/check-runs?check_name=agent-review" \
             | jq -r --arg external_id "agent-review:pr:${PR_NUMBER}:head:${HEAD_SHA}:" \
               '[.check_runs[] | select(.external_id != null and (.external_id | startswith($external_id)))]
                | any(.[]; .conclusion == "success")')"
           if test "$existing_success" = true; then
+            publish_success_attestation
+            continue_automated_stewardship
             echo "Exact-head agent review is already successful; skipping duplicate run"
             exit 0
           fi
@@ -78,15 +99,8 @@ jobs:
             gh api --method PATCH "repos/${GITHUB_REPOSITORY}/check-runs/${check_id}" \
               -f status='completed' -f conclusion='success' >/dev/null
             check_finished=true
-            gh workflow run safe-auto-merge-request.yml --repo "$GITHUB_REPOSITORY" --ref main \
-              -f pr_number="$PR_NUMBER" -f head_sha="$HEAD_SHA"
-            if gh api "repos/${GITHUB_REPOSITORY}/contents/.github/workflows/strategy-integrate-reviewed.yml?ref=main" \
-              >/dev/null 2>&1; then
-              gh workflow run strategy-integrate-reviewed.yml --repo "$GITHUB_REPOSITORY" --ref main \
-                -f pr_number="$PR_NUMBER" -f head_sha="$HEAD_SHA"
-            else
-              echo "Reviewed-result integration is not installed on main yet"
-            fi
+            publish_success_attestation
+            continue_automated_stewardship
           }
           trap finish_check EXIT
 

--- a/src/master-plan-controller/__tests__/workflow-governance.test.ts
+++ b/src/master-plan-controller/__tests__/workflow-governance.test.ts
@@ -134,7 +134,15 @@ describe('blocking CI and governed workflows', () => {
     expect(agentReview).toContain('actions: write');
     expect(agentReview).toContain('commit_id');
     expect(agentReview).toContain('checks: write');
+    expect(agentReview).toContain('statuses: write');
     expect(agentReview).toContain('/check-runs');
+    expect(agentReview).toContain('repos/${GITHUB_REPOSITORY}/statuses/${HEAD_SHA}');
+    expect(agentReview).toContain("-f state='success'");
+    expect(agentReview).toContain("-f context='agent-review'");
+    expect(agentReview).toContain('actions/runs/${GITHUB_RUN_ID}');
+    expect(agentReview).toContain('Exact-head agent review run ${GITHUB_RUN_ID} passed');
+    expect(agentReview).toMatch(/if test "\$existing_success" = true; then\s+publish_success_attestation/s);
+    expect(agentReview).toMatch(/complete_success\(\).*conclusion='success'.*publish_success_attestation/s);
     expect(agentReview).toContain('gh workflow run strategy-integrate-reviewed.yml');
     expect(agentReview).toContain('contents/.github/workflows/strategy-integrate-reviewed.yml?ref=main');
     expect(agentReview).toContain('Exact-head agent review is already successful; skipping duplicate run');


### PR DESCRIPTION
## What changed

- publish an exact-head `agent-review` commit status after successful independent review
- re-attest and redispatch automated stewardship when an exact-head review already succeeded
- grant only the status permission required for that attestation
- add governance regression coverage

## Why

GitHub could show a successful exact-head check run while branch protection still reported the required `agent-review` context as expected. That left a routine merge dependent on operator repair, contrary to the automated-body/servant-leader policy.

## Validation

- focused workflow governance tests
- full test suite
- TypeScript typecheck
- strategy v2 verification
- `git diff --check`