### PR TITLE
Add production strategy observation

### DIFF
--- a/.github/workflows/strategy-cycle.yml
+++ b/.github/workflows/strategy-cycle.yml
@@ -28,15 +28,23 @@ jobs:
           node-version: 24
           cache: npm
       - run: npm ci
-      - name: Generate and publish a bounded candidate frontier
+      - name: Observe, diagnose, and publish a bounded strategy update
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
           cycle_time="$(date -u +'%Y-%m-%dT%H:%M:%S.000Z')"
+          npm run strategy:observe -- "$cycle_time"
           npm run strategy:generate -- "$cycle_time"
-          if git diff --quiet -- strategy/work-packets.json strategy/audit-log.json; then
-            echo "No bounded candidate is currently available"
+          strategy_paths=(
+            strategy/evidence.json
+            strategy/graph.json
+            strategy/assessments.json
+            strategy/work-packets.json
+            strategy/audit-log.json
+          )
+          if git diff --quiet -- "${strategy_paths[@]}"; then
+            echo "No new external evidence or bounded candidate is currently available"
             exit 0
           fi
           git fetch origin main
@@ -46,8 +54,8 @@ jobs:
           git config user.name github-actions[bot]
           git config user.email 41898282+github-actions[bot]@users.noreply.github.com
           git switch -c "$branch"
-          git add strategy/work-packets.json strategy/audit-log.json
-          git commit -m "Generate bounded strategy candidate"
+          git add "${strategy_paths[@]}"
+          git commit -m "Observe and generate bounded strategy update"
           head_sha="$(git rev-parse HEAD)"
           commit_count="$(git rev-list --count origin/main..HEAD)"
           test "$commit_count" -eq 1
@@ -57,8 +65,8 @@ jobs:
           BASE_SHA="$base_sha" HEAD_SHA="$head_sha" PR_COMMIT_COUNT="$commit_count" npm run governance:classify
           git push --set-upstream origin "$branch"
           pr_url="$(gh pr create --base main --head "$branch" \
-            --title "Generate bounded strategy candidate" \
-            --body "Automated diagnosis-driven candidate generation at ${cycle_time}. The change is one commit and remains subject to all required checks and independent agent review.")"
+            --title "Observe and generate bounded strategy update" \
+            --body "Automated external observation and diagnosis-driven candidate generation at ${cycle_time}. The change is one commit and remains subject to all required checks and independent agent review.")"
           pr_number="$(gh pr view "$pr_url" --json number --jq '.number')"
           for check_name in typecheck test strategy-verify proposal-review safe-auto-merge; do
             gh api --method POST "repos/${GITHUB_REPOSITORY}/check-runs" \

--- a/STATUS.md
+++ b/STATUS.md
@@ -1,6 +1,6 @@
 # MASTER_PLAN v2 — Status and operating model
 
-As of 2026-08-03, the v2 strategy/controller operates through continuous automated stewardship.
+As of 2026-08-04, the v2 strategy/controller operates through continuous automated stewardship.
 Implementation readiness is not real-world outcome attainment.
 
 ## Current controls
@@ -27,26 +27,29 @@ contacted only for an evidence-backed issue that automation intrinsically cannot
 - `src/master-plan-controller/`: pure graph/evidence/gate evaluation, lexical G1 ranking, bounded
   decomposition, lifecycle/audit integration, crash recovery, authority classification, rollout
   gates, verify-before-integrate evidence handling, configurable review freshness, strict public
-  contract validation, and injected environment ports with in-memory implementations.
+  contract validation, credential-independent live-control observation, and injected environment
+  ports with in-memory implementations.
 - `.github/workflows/`: blocking typecheck/test/strategy checks, proposal review, and a narrowly
   scoped routine-code workflow and an agent-controlled protected-change path.
 - `src/simulation/`, `src/simulation-ui/`, and the cognitive stack: candidate reusable components.
 
 ## Automated operating procedure
 
-1. Historical shadow records preserve initial automated calibration and its limitations. No record
+1. Scheduled cycles observe configured external state, deduplicate snapshots, integrate evidence,
+   and update affected hypotheses before diagnosis.
+2. Historical shadow records preserve initial automated calibration and its limitations. No record
    count or human approval is required to operate.
-2. The automated operating body executes one bounded packet at a time; every result receives fresh
+3. The automated operating body executes one bounded packet at a time; every result receives fresh
    independent agent review before integration.
-3. Routine code/test changes auto-merge after classification, tests, protected controls, and agent
+4. Routine code/test changes auto-merge after classification, tests, protected controls, and agent
    review. Protected changes use an agent-controlled merge.
-4. Automation diagnoses failures, retries bounded alternatives, and records evidence without
+5. Automation diagnoses failures, retries bounded alternatives, and records evidence without
    transferring routine work to the human.
-5. Escalation is permitted only for owner-held credentials, physical presence, legal consent, or
+6. Escalation is permitted only for owner-held credentials, physical presence, legal consent, or
    unresolved constitutional conflict after at least two documented automated attempts.
-6. The escalation request contains evidence and asks the servant leader for exactly one bounded
+7. The escalation request contains evidence and asks the servant leader for exactly one bounded
    decision. A required repository change is isolated to one auditable commit.
-7. Portfolio review runs weekly; weights, evidence standards, and constitutional risks receive
+8. Portfolio review runs weekly; weights, evidence standards, and constitutional risks receive
    quarterly independent agent review.
 
 When no packet is eligible, the controller waits for evidence or an automated dependency. It does

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "build": "tsc",
     "lint": "tsc --noEmit",
     "strategy:verify": "tsx src/master-plan-controller/cli/verify-strategy.ts",
+    "strategy:observe": "tsx src/master-plan-controller/cli/observe-repository-main.ts",
     "strategy:generate": "tsx src/master-plan-controller/cli/generate-candidates-main.ts",
     "strategy:execute": "tsx src/master-plan-controller/cli/execute-packet-main.ts",
     "strategy:integrate-reviewed-execution": "tsx src/master-plan-controller/cli/integrate-reviewed-execution-main.ts",

--- a/src/master-plan-controller/__tests__/repository-observation.test.ts
+++ b/src/master-plan-controller/__tests__/repository-observation.test.ts
@@ -1,0 +1,187 @@
+import { describe, expect, it } from 'vitest';
+import {
+  GitHubRepositoryControlObserver,
+  runRepositoryObservation,
+  type RepositoryControlObservationConfig,
+} from '../repository-observation.js';
+import { runRepositoryObservationCli } from '../cli/observe-repository.js';
+import { NodeFileSystem } from '../runtime-adapters.js';
+import {
+  InMemoryExternalData,
+  InMemoryFileSystem,
+  InMemoryNetwork,
+} from '../testing/in-memory-adapters.js';
+import { advanceTimestamp, nextRepositoryTimestamp } from './repository-test-time.js';
+
+const NOW = '2026-08-04T05:00:00.000Z';
+const REPOSITORY_URL = 'https://api.github.com/repos/owner/repo';
+const PROTECTION_URL = `${REPOSITORY_URL}/branches/main`;
+const CONFIG: RepositoryControlObservationConfig = {
+  repository: 'owner/repo',
+  branch: 'main',
+  hypothesisId: 'hypothesis-live-stewardship-controls-aligned',
+  branchProtected: true,
+  requiredStatusChecks: ['typecheck', 'test', 'strategy-verify', 'proposal-review', 'agent-review'],
+  enforceAdmins: true,
+};
+
+function responses(overrides: { checks?: string[] } = {}) {
+  return {
+    [`GET ${PROTECTION_URL}`]: {
+      status: 200,
+      body: JSON.stringify({
+        protected: true,
+        protection: {
+          required_status_checks: {
+            enforcement_level: 'everyone',
+            contexts: overrides.checks ?? CONFIG.requiredStatusChecks,
+          },
+        },
+      }),
+    },
+  };
+}
+
+async function repositorySnapshot(): Promise<Record<string, string>> {
+  const source = new NodeFileSystem('.');
+  const paths = [...await source.listFiles('strategy/'), ...await source.listFiles('plan/')];
+  return Object.fromEntries(await Promise.all(paths.map(async (path) => [path, await source.readText(path)])));
+}
+
+describe('live repository control observation', () => {
+  it('emits bounded positive evidence when live controls match policy', async () => {
+    const network = new InMemoryNetwork(responses());
+    const observer = new GitHubRepositoryControlObserver(network, CONFIG, 'token');
+
+    const [evidence] = await observer.observe(NOW);
+
+    expect(network.requests).toEqual([
+      { method: 'GET', url: PROTECTION_URL, headers: { Accept: 'application/vnd.github+json', Authorization: 'Bearer token' } },
+    ]);
+    expect(evidence).toMatchObject({
+      outcome: 'positive',
+      observedAt: NOW,
+      supportedHypotheses: [CONFIG.hypothesisId],
+      falsifiedHypotheses: [],
+      verifier: 'deterministic-live-repository-control-observer:v1',
+    });
+    expect(evidence.claim).toMatch(/match/i);
+    expect(evidence.limitations.join(' ')).toMatch(/snapshot/i);
+  });
+
+  it('emits stable negative evidence with explicit drift details', async () => {
+    const observer = new GitHubRepositoryControlObserver(new InMemoryNetwork(responses({
+      checks: ['typecheck'],
+    })), CONFIG);
+
+    const [first] = await observer.observe(NOW);
+    const [second] = await observer.observe(advanceTimestamp(NOW));
+
+    expect(first).toMatchObject({
+      outcome: 'negative',
+      supportedHypotheses: [],
+      falsifiedHypotheses: [CONFIG.hypothesisId],
+    });
+    expect(first.id).toBe(second.id);
+    expect(first.claim).toMatch(/drift/i);
+    expect(first.method).toMatch(/branchProtected.*requiredStatusChecks/s);
+  });
+
+  it('fails closed on unavailable or malformed external state', async () => {
+    const unavailable = new GitHubRepositoryControlObserver(new InMemoryNetwork({
+      [`GET ${PROTECTION_URL}`]: { status: 503, body: 'unavailable' },
+    }), CONFIG);
+    await expect(unavailable.observe(NOW)).rejects.toThrow(/503/);
+
+    const malformed = new GitHubRepositoryControlObserver(new InMemoryNetwork({
+      [`GET ${PROTECTION_URL}`]: { status: 200, body: '{}' },
+    }), CONFIG);
+    await expect(malformed.observe(NOW)).rejects.toThrow(/malformed/i);
+  });
+
+  it('integrates observed evidence and hypothesis confidence before diagnosis', async () => {
+    const initial = await repositorySnapshot();
+    const fileSystem = new InMemoryFileSystem(initial);
+    const now = nextRepositoryTimestamp(initial);
+    const evidence = {
+      id: 'evidence-live-controls-test',
+      claim: 'Live repository controls match policy.',
+      method: 'Deterministic comparison.',
+      source: 'https://api.github.com/repos/owner/repo/branches/main/protection',
+      strength: 0.6,
+      limitations: ['One point-in-time external control-plane snapshot.'],
+      supportedHypotheses: ['hypothesis-live-stewardship-controls-aligned'],
+      falsifiedHypotheses: [],
+      verifier: 'test-observer',
+      observedAt: now,
+      outcome: 'positive' as const,
+    };
+
+    const result = await runRepositoryObservation(
+      fileSystem,
+      new InMemoryExternalData([[evidence]]),
+      now,
+    );
+
+    expect(result).toEqual({ observedEvidenceIds: [evidence.id], integratedEvidenceIds: [evidence.id] });
+    const storedEvidence = JSON.parse(await fileSystem.readText('strategy/evidence.json')) as Array<{ id: string }>;
+    expect(storedEvidence.at(-1)?.id).toBe(evidence.id);
+    const graph = JSON.parse(await fileSystem.readText('strategy/graph.json')) as Array<{
+      id: string; confidence: number; evidenceReferences: string[];
+    }>;
+    const hypothesis = graph.find((node) => node.id === 'hypothesis-live-stewardship-controls-aligned')!;
+    expect(hypothesis.evidenceReferences).toContain(evidence.id);
+    expect(hypothesis.confidence).toBeGreaterThan(0.5);
+  });
+
+  it('is byte-idempotent when an external snapshot was already integrated', async () => {
+    const initial = await repositorySnapshot();
+    const fileSystem = new InMemoryFileSystem(initial);
+    const evidence = (JSON.parse(initial['strategy/evidence.json']) as Array<Record<string, unknown>>)[0] as never;
+    const before = {
+      evidence: await fileSystem.readText('strategy/evidence.json'),
+      graph: await fileSystem.readText('strategy/graph.json'),
+      assessments: await fileSystem.readText('strategy/assessments.json'),
+    };
+
+    const result = await runRepositoryObservation(
+      fileSystem,
+      new InMemoryExternalData([[evidence]]),
+      nextRepositoryTimestamp(initial),
+    );
+
+    expect(result.integratedEvidenceIds).toEqual([]);
+    expect(await fileSystem.readText('strategy/evidence.json')).toBe(before.evidence);
+    expect(await fileSystem.readText('strategy/graph.json')).toBe(before.graph);
+    expect(await fileSystem.readText('strategy/assessments.json')).toBe(before.assessments);
+  });
+
+  it('validates a duplicate snapshot before treating it as idempotent', async () => {
+    const initial = await repositorySnapshot();
+    const fileSystem = new InMemoryFileSystem(initial);
+    const now = nextRepositoryTimestamp(initial);
+    const existing = (JSON.parse(initial['strategy/evidence.json']) as Array<Record<string, unknown>>)[0];
+    const replay = { ...existing, observedAt: advanceTimestamp(now) } as never;
+
+    await expect(runRepositoryObservation(
+      fileSystem,
+      new InMemoryExternalData([[replay]]),
+      now,
+    )).rejects.toThrow(/future/i);
+
+    expect(await fileSystem.readText('strategy/evidence.json')).toBe(initial['strategy/evidence.json']);
+    expect(await fileSystem.readText('strategy/graph.json')).toBe(initial['strategy/graph.json']);
+  });
+
+  it('exposes an explicit timestamp CLI boundary', async () => {
+    const initial = await repositorySnapshot();
+    const fileSystem = new InMemoryFileSystem(initial);
+    const now = nextRepositoryTimestamp(initial);
+    const externalData = new InMemoryExternalData();
+
+    expect(JSON.parse(await runRepositoryObservationCli(fileSystem, externalData, [now])))
+      .toEqual({ observedEvidenceIds: [], integratedEvidenceIds: [] });
+    await expect(runRepositoryObservationCli(fileSystem, externalData, [])).rejects.toThrow(/usage/i);
+    await expect(runRepositoryObservationCli(fileSystem, externalData, [now, now])).rejects.toThrow(/usage/i);
+  });
+});

--- a/src/master-plan-controller/__tests__/repository-packet-execution.test.ts
+++ b/src/master-plan-controller/__tests__/repository-packet-execution.test.ts
@@ -21,6 +21,7 @@ const STRATEGY_FILES = [
   'strategy/shadow-reviews.json',
   'strategy/legacy-audit.json',
   'strategy/packet-templates.json',
+  'strategy/observation-sources.json',
   'strategy/ROADMAP.md',
   'STATUS.md',
 ] as const;

--- a/src/master-plan-controller/__tests__/repository-result-integration.test.ts
+++ b/src/master-plan-controller/__tests__/repository-result-integration.test.ts
@@ -25,6 +25,7 @@ const STRATEGY_FILES = [
   'strategy/shadow-reviews.json',
   'strategy/legacy-audit.json',
   'strategy/packet-templates.json',
+  'strategy/observation-sources.json',
   'strategy/ROADMAP.md',
   'STATUS.md',
 ] as const;

--- a/src/master-plan-controller/__tests__/strategy-artifacts.test.ts
+++ b/src/master-plan-controller/__tests__/strategy-artifacts.test.ts
@@ -148,6 +148,7 @@ describe('checked-in strategy v2 bundle', () => {
     } as never);
     bundle.config.maxDecompositionDepth = 5;
     bundle.config.maxChildrenPerDecomposition = 6;
+    bundle.observationSources[0].hypothesisId = 'missing-observation-hypothesis';
 
     const errors = (await verifyRepositoryStrategy(fileSystem, bundle, STRATEGY_NOW)).errors.join('\n');
     expect(errors).toMatch(/evidence.*future/i);
@@ -159,6 +160,7 @@ describe('checked-in strategy v2 bundle', () => {
     expect(errors).toMatch(/constitutional amendment/i);
     expect(errors).toMatch(/decomposition depth/i);
     expect(errors).toMatch(/children/i);
+    expect(errors).toMatch(/observation source.*missing hypothesis/i);
   });
 
   it('fails closed on an escalation assessment with an invalid timestamp', async () => {
@@ -177,7 +179,8 @@ describe('checked-in strategy v2 bundle', () => {
   });
 
   it('contains the constitutional core, exact portfolio weights, and disabled-by-default automation', async () => {
-    const bundle = await loadRepositoryStrategy(new NodeFileSystem('.'));
+    const fileSystem = new NodeFileSystem('.');
+    const bundle = await loadRepositoryStrategy(fileSystem);
     expect(bundle.state.constitution.directives).toEqual(['G1', 'G2', 'G3']);
     expect(bundle.config.portfolioWeights).toEqual({
       'consciousness-epistemics': 0.35,
@@ -193,6 +196,18 @@ describe('checked-in strategy v2 bundle', () => {
       'enabling-capabilities',
       'institutional-continuity',
     ]));
+    expect(bundle.state.nodes.find((node) => node.id === 'hypothesis-live-stewardship-controls-aligned'))
+      .toMatchObject({ kind: 'hypothesis', portfolio: 'institutional-continuity', lifecycle: 'eligible' });
+    const observation = JSON.parse(await fileSystem.readText('strategy/observation-sources.json')) as {
+      sources: Array<{ kind: string; branch: string; hypothesisId: string }>;
+    };
+    expect(observation.sources).toEqual([{
+      kind: 'github-repository-controls',
+      branch: 'main',
+      hypothesisId: 'hypothesis-live-stewardship-controls-aligned',
+    }]);
+    expect(await fileSystem.readText('strategy/ROADMAP.md'))
+      .toContain('Scheduled cycles integrate deduplicated external observations before diagnosis.');
   });
 
   it('provides bounded automated generation coverage across every active portfolio', async () => {

--- a/src/master-plan-controller/__tests__/workflow-governance.test.ts
+++ b/src/master-plan-controller/__tests__/workflow-governance.test.ts
@@ -192,7 +192,14 @@ describe('blocking CI and governed workflows', () => {
     expect(strategyCycle).toContain('git rev-list --count origin/main..HEAD');
     expect(strategyCycle).toContain('PR_COMMIT_COUNT="$commit_count"');
     expect(strategyCycle).not.toContain('PR_COMMIT_COUNT=1');
+    expect(strategyCycle).toContain('npm run strategy:observe');
     expect(strategyCycle).toContain('npm run strategy:generate');
+    expect(strategyCycle.indexOf('npm run strategy:observe')).toBeLessThan(
+      strategyCycle.indexOf('npm run strategy:generate'),
+    );
+    for (const observedPath of ['strategy/evidence.json', 'strategy/graph.json', 'strategy/assessments.json']) {
+      expect(strategyCycle).toContain(observedPath);
+    }
     expect(strategyCycle).toContain('git diff --quiet');
     expect(strategyCycle).toContain('gh pr create');
     expect(strategyCycle).toContain('gh pr merge');
@@ -250,6 +257,7 @@ describe('blocking CI and governed workflows', () => {
     const packageJson = JSON.parse(await fileSystem.readText('package.json')) as { scripts: Record<string, string> };
     expect(packageJson.scripts).toMatchObject({
       'strategy:verify': 'tsx src/master-plan-controller/cli/verify-strategy.ts',
+      'strategy:observe': 'tsx src/master-plan-controller/cli/observe-repository-main.ts',
       'governance:classify': 'tsx src/master-plan-controller/cli/classify-change.ts',
       'auto-merge:evaluate': 'tsx src/master-plan-controller/cli/evaluate-auto-merge.ts',
       'strategy:generate': 'tsx src/master-plan-controller/cli/generate-candidates-main.ts',

--- a/src/master-plan-controller/cli/observe-repository-main.ts
+++ b/src/master-plan-controller/cli/observe-repository-main.ts
@@ -1,0 +1,28 @@
+import {
+  CompositeExternalData,
+  GitHubRepositoryControlObserver,
+  loadRepositoryControlObservationConfigs,
+} from '../repository-observation.js';
+import { FetchNetwork, NodeFileSystem } from '../runtime-adapters.js';
+import { runRepositoryObservationCli } from './observe-repository.js';
+import { NodeCliRuntime } from './runtime.js';
+
+async function main(): Promise<void> {
+  const cli = new NodeCliRuntime();
+  const fileSystem = new NodeFileSystem(cli.environment('GITHUB_WORKSPACE') ?? '.');
+  try {
+    const repository = cli.environment('GITHUB_REPOSITORY');
+    if (!repository) throw new Error('GITHUB_REPOSITORY is required');
+    const network = new FetchNetwork();
+    const configs = await loadRepositoryControlObservationConfigs(fileSystem, repository);
+    const externalData = new CompositeExternalData(
+      configs.map((config) => new GitHubRepositoryControlObserver(network, config)),
+    );
+    cli.write(await runRepositoryObservationCli(fileSystem, externalData, cli.arguments()));
+  } catch (error) {
+    cli.writeError(error instanceof Error ? error.message : String(error));
+    cli.fail();
+  }
+}
+
+void main();

--- a/src/master-plan-controller/cli/observe-repository.ts
+++ b/src/master-plan-controller/cli/observe-repository.ts
@@ -1,0 +1,15 @@
+import type { ExternalDataPort, FileSystemPort } from '../ports.js';
+import { runRepositoryObservation } from '../repository-observation.js';
+import type { Timestamp } from '../types.js';
+
+export async function runRepositoryObservationCli(
+  fileSystem: FileSystemPort,
+  externalData: ExternalDataPort,
+  args: readonly string[],
+): Promise<string> {
+  const [now, ...extra] = args;
+  if (!now || extra.length > 0 || Number.isNaN(Date.parse(now))) {
+    throw new Error('Usage: strategy:observe <ISO timestamp>');
+  }
+  return JSON.stringify(await runRepositoryObservation(fileSystem, externalData, now as Timestamp));
+}

--- a/src/master-plan-controller/index.ts
+++ b/src/master-plan-controller/index.ts
@@ -16,6 +16,7 @@ export * from './ports.js';
 export * from './process-adapters.js';
 export * from './proposal-policy.js';
 export * from './repository-strategy.js';
+export * from './repository-observation.js';
 export * from './roadmap.js';
 export * from './rollout.js';
 export * from './runtime-adapters.js';

--- a/src/master-plan-controller/repository-observation.ts
+++ b/src/master-plan-controller/repository-observation.ts
@@ -1,0 +1,246 @@
+import { evidenceValidationErrors, integrateEvidence } from './evidence.js';
+import type { ExternalDataPort, FileSystemPort, NetworkPort, NetworkRequest } from './ports.js';
+import { appendRepositoryJsonArrayItems, formattedRepositoryJson } from './repository-json.js';
+import { loadRepositoryStrategy, verifyRepositoryStrategy } from './repository-strategy.js';
+import type { EvidenceRecord, Timestamp } from './types.js';
+
+export interface RepositoryControlObservationConfig {
+  repository: string;
+  branch: string;
+  hypothesisId: string;
+  branchProtected: boolean;
+  requiredStatusChecks: string[];
+  enforceAdmins: boolean;
+}
+
+interface BranchResponse {
+  protected?: boolean;
+  protection?: {
+    required_status_checks?: {
+      enforcement_level?: string;
+      contexts?: string[];
+      checks?: Array<{ context?: string }>;
+    };
+  };
+}
+
+interface LiveRepositoryControls {
+  branchProtected: boolean;
+  requiredStatusChecks: string[];
+  enforceAdmins: boolean;
+}
+
+export interface RepositoryObservationResult {
+  observedEvidenceIds: string[];
+  integratedEvidenceIds: string[];
+}
+
+interface ObservationSourcesFile {
+  sources: Array<{
+    kind: 'github-repository-controls';
+    branch: string;
+    hypothesisId: string;
+  }>;
+}
+
+interface BranchProtectionPolicyFile {
+  appliedAndVerified: boolean;
+  requiredStatusChecks: string[];
+  enforceAdmins: boolean;
+}
+
+function sortedUnique(values: readonly string[]): string[] {
+  return [...new Set(values)].sort((left, right) => left.localeCompare(right));
+}
+
+function stableFingerprint(value: string): string {
+  let hash = 0xcbf29ce484222325n;
+  for (const character of value) {
+    hash ^= BigInt(character.codePointAt(0) ?? 0);
+    hash = BigInt.asUintN(64, hash * 0x100000001b3n);
+  }
+  return hash.toString(16).padStart(16, '0');
+}
+
+function parseJson<T>(body: string, label: string): T {
+  try {
+    return JSON.parse(body) as T;
+  } catch {
+    throw new Error(`${label} response is malformed`);
+  }
+}
+
+function assertBoolean(value: unknown, label: string): asserts value is boolean {
+  if (typeof value !== 'boolean') throw new Error(`Live repository controls are malformed: ${label}`);
+}
+
+function liveControls(branch: BranchResponse): LiveRepositoryControls {
+  const statusChecks = branch.protection?.required_status_checks;
+  const checks = sortedUnique([
+    ...(statusChecks?.contexts ?? []),
+    ...(statusChecks?.checks ?? []).flatMap((check) => check.context ? [check.context] : []),
+  ]);
+  assertBoolean(branch.protected, 'branchProtected');
+  if (!statusChecks || checks.length === 0 || typeof statusChecks.enforcement_level !== 'string') {
+    throw new Error('Live repository controls are malformed: requiredStatusChecks');
+  }
+  return {
+    branchProtected: branch.protected,
+    requiredStatusChecks: checks,
+    enforceAdmins: statusChecks.enforcement_level === 'everyone',
+  };
+}
+
+function drift(expected: RepositoryControlObservationConfig, live: LiveRepositoryControls): string[] {
+  const mismatches: string[] = [];
+  const expectedChecks = sortedUnique(expected.requiredStatusChecks);
+  if (JSON.stringify(live.requiredStatusChecks) !== JSON.stringify(expectedChecks)) {
+    mismatches.push(`required status checks expected ${expectedChecks.join(',')} but observed ${live.requiredStatusChecks.join(',')}`);
+  }
+  for (const field of ['branchProtected', 'enforceAdmins'] as const) {
+    if (live[field] !== expected[field]) {
+      mismatches.push(`${field} expected ${String(expected[field])} but observed ${String(live[field])}`);
+    }
+  }
+  return mismatches;
+}
+
+export class GitHubRepositoryControlObserver implements ExternalDataPort {
+  constructor(
+    private readonly network: NetworkPort,
+    private readonly config: RepositoryControlObservationConfig,
+    private readonly token?: string,
+  ) {}
+
+  async observe(now: Timestamp): Promise<EvidenceRecord[]> {
+    if (Number.isNaN(Date.parse(now))) throw new Error('A valid caller-supplied observation timestamp is required');
+    const baseUrl = `https://api.github.com/repos/${this.config.repository}`;
+    const headers: Record<string, string> = { Accept: 'application/vnd.github+json' };
+    if (this.token?.trim()) headers.Authorization = `Bearer ${this.token}`;
+    const request = async (url: string, label: string): Promise<string> => {
+      const networkRequest: NetworkRequest = { method: 'GET', url, headers };
+      const response = await this.network.request(networkRequest);
+      if (response.status < 200 || response.status >= 300) {
+        throw new Error(`${label} observation failed with HTTP ${response.status}`);
+      }
+      return response.body;
+    };
+    const branchUrl = `${baseUrl}/branches/${encodeURIComponent(this.config.branch)}`;
+    const branch = parseJson<BranchResponse>(
+      await request(branchUrl, 'Branch controls'),
+      'Branch controls',
+    );
+    const live = liveControls(branch);
+    const mismatches = drift(this.config, live);
+    const aligned = mismatches.length === 0;
+    const fingerprint = stableFingerprint(JSON.stringify({ live, mismatches }));
+    return [{
+      id: `evidence-live-repository-controls-${fingerprint}`,
+      claim: aligned
+        ? `Publicly observable live ${this.config.repository}/${this.config.branch} controls match the corresponding checked-in stewardship policy fields.`
+        : `Publicly observable live ${this.config.repository}/${this.config.branch} controls have policy drift: ${mismatches.join('; ')}.`,
+      method: `Deterministic GitHub API comparison observed ${JSON.stringify(live)}; ${
+        aligned ? 'no mismatches' : mismatches.join('; ')}.`,
+      source: branchUrl,
+      strength: 0.55,
+      limitations: [
+        'This is a point-in-time GitHub control-plane snapshot, not proof that controls cannot change afterward.',
+        'The public branch response does not expose strict update requirements, review count, conversation resolution, force-push, or deletion controls; those fields remain covered by protected workflow checks and privileged audits.',
+      ],
+      supportedHypotheses: aligned ? [this.config.hypothesisId] : [],
+      falsifiedHypotheses: aligned ? [] : [this.config.hypothesisId],
+      verifier: 'deterministic-live-repository-control-observer:v1',
+      observedAt: now,
+      outcome: aligned ? 'positive' : 'negative',
+    }];
+  }
+}
+
+export class CompositeExternalData implements ExternalDataPort {
+  constructor(private readonly sources: readonly ExternalDataPort[]) {}
+
+  async observe(now: Timestamp): Promise<EvidenceRecord[]> {
+    return (await Promise.all(this.sources.map(async (source) => source.observe(now)))).flat();
+  }
+}
+
+export async function loadRepositoryControlObservationConfigs(
+  fileSystem: FileSystemPort,
+  repository: string,
+): Promise<RepositoryControlObservationConfig[]> {
+  if (!/^[^/\s]+\/[^/\s]+$/.test(repository)) throw new Error('A valid GitHub repository identity is required');
+  const [sources, policy] = await Promise.all([
+    fileSystem.readText('strategy/observation-sources.json'),
+    fileSystem.readText('strategy/branch-protection.json'),
+  ]);
+  const parsedSources = parseJson<ObservationSourcesFile>(sources, 'Observation sources');
+  const parsedPolicy = parseJson<BranchProtectionPolicyFile>(policy, 'Branch protection policy');
+  if (!Array.isArray(parsedSources.sources) || parsedSources.sources.length === 0) {
+    throw new Error('At least one external observation source is required');
+  }
+  return parsedSources.sources.map((source) => {
+    if (source.kind !== 'github-repository-controls' || !source.branch?.trim() || !source.hypothesisId?.trim()) {
+      throw new Error('Repository control observation source is malformed');
+    }
+    return {
+      repository,
+      branch: source.branch,
+      hypothesisId: source.hypothesisId,
+      branchProtected: parsedPolicy.appliedAndVerified,
+      requiredStatusChecks: sortedUnique(parsedPolicy.requiredStatusChecks),
+      enforceAdmins: parsedPolicy.enforceAdmins,
+    };
+  });
+}
+
+function sameSnapshotEvidence(left: EvidenceRecord, right: EvidenceRecord): boolean {
+  const withoutObservationTime = ({ observedAt: _observedAt, ...record }: EvidenceRecord) => record;
+  return JSON.stringify(withoutObservationTime(left)) === JSON.stringify(withoutObservationTime(right));
+}
+
+export async function runRepositoryObservation(
+  fileSystem: FileSystemPort,
+  externalData: ExternalDataPort,
+  now: Timestamp,
+): Promise<RepositoryObservationResult> {
+  if (Number.isNaN(Date.parse(now))) throw new Error('A valid caller-supplied timestamp is required');
+  const bundle = await loadRepositoryStrategy(fileSystem);
+  const before = await verifyRepositoryStrategy(fileSystem, bundle, now);
+  if (before.errors.length > 0) throw new Error(`Strategy verification failed: ${before.errors.join('; ')}`);
+  const observed = await externalData.observe(now);
+  let state = bundle.state;
+  const integratedEvidenceIds: string[] = [];
+  for (const evidence of observed) {
+    const validationErrors = evidenceValidationErrors(state, evidence, now);
+    if (validationErrors.length > 0) throw new Error(validationErrors.join('; '));
+    const existing = state.evidence.find((record) => record.id === evidence.id);
+    if (existing) {
+      if (!sameSnapshotEvidence(existing, evidence)) {
+        throw new Error(`Observed evidence identity collides with different content: ${evidence.id}`);
+      }
+      continue;
+    }
+    state = integrateEvidence(state, evidence, now, bundle.config);
+    integratedEvidenceIds.push(evidence.id);
+  }
+  if (integratedEvidenceIds.length === 0) {
+    return { observedEvidenceIds: observed.map((record) => record.id), integratedEvidenceIds };
+  }
+  const updated = { ...bundle, state };
+  const after = await verifyRepositoryStrategy(fileSystem, updated, now);
+  if (after.errors.length > 0) throw new Error(`Observed strategy failed verification: ${after.errors.join('; ')}`);
+  const [evidenceText, assessmentsText] = await Promise.all([
+    fileSystem.readText('strategy/evidence.json'),
+    fileSystem.readText('strategy/assessments.json'),
+  ]);
+  await fileSystem.writeText(
+    'strategy/evidence.json',
+    appendRepositoryJsonArrayItems(evidenceText, bundle.state.evidence, state.evidence),
+  );
+  await fileSystem.writeText('strategy/graph.json', formattedRepositoryJson(state.nodes));
+  await fileSystem.writeText(
+    'strategy/assessments.json',
+    appendRepositoryJsonArrayItems(assessmentsText, bundle.state.assessments, state.assessments),
+  );
+  return { observedEvidenceIds: observed.map((record) => record.id), integratedEvidenceIds };
+}

--- a/src/master-plan-controller/repository-strategy.ts
+++ b/src/master-plan-controller/repository-strategy.ts
@@ -44,6 +44,13 @@ export interface RepositoryStrategyBundle {
   config: ControllerConfig;
   legacyAudit: LegacyAuditRecord[];
   packetTemplates: DiagnosticPacketTemplate[];
+  observationSources: RepositoryObservationSource[];
+}
+
+export interface RepositoryObservationSource {
+  kind: 'github-repository-controls';
+  branch: string;
+  hypothesisId: string;
 }
 
 async function json<T>(fileSystem: FileSystemPort, path: string): Promise<T> {
@@ -66,6 +73,7 @@ export async function loadRepositoryStrategy(fileSystem: FileSystemPort): Promis
     shadowCycleReviews,
     legacyAudit,
     packetTemplates,
+    observationSourcesFile,
   ] = await Promise.all([
     json<Constitution>(fileSystem, 'strategy/constitution.json'),
     json<unknown>(fileSystem, 'strategy/graph.json'),
@@ -81,6 +89,7 @@ export async function loadRepositoryStrategy(fileSystem: FileSystemPort): Promis
     json<ShadowCycleReview[]>(fileSystem, 'strategy/shadow-reviews.json'),
     json<LegacyAuditRecord[]>(fileSystem, 'strategy/legacy-audit.json'),
     json<DiagnosticPacketTemplate[]>(fileSystem, 'strategy/packet-templates.json'),
+    json<{ sources: RepositoryObservationSource[] }>(fileSystem, 'strategy/observation-sources.json'),
   ]);
   const nodes = parsePlanNodes(graphInput);
   const state: StrategyState = {
@@ -102,6 +111,7 @@ export async function loadRepositoryStrategy(fileSystem: FileSystemPort): Promis
     state,
     legacyAudit,
     packetTemplates,
+    observationSources: observationSourcesFile.sources,
     config: {
       portfolioWeights: portfolio.weights,
       scoreWeights: portfolio.scoreWeights,
@@ -170,6 +180,22 @@ export async function verifyRepositoryStrategy(
     }
   }
   const nodeIds = new Set(bundle.state.nodes.map((node) => node.id));
+  if (!Array.isArray(bundle.observationSources) || bundle.observationSources.length === 0) {
+    errors.push('At least one external observation source is required');
+  } else {
+    const sourceKeys = new Set<string>();
+    for (const source of bundle.observationSources) {
+      const key = `${source.kind}:${source.branch}:${source.hypothesisId}`;
+      if (sourceKeys.has(key)) errors.push(`Duplicate observation source: ${key}`);
+      sourceKeys.add(key);
+      const hypothesis = bundle.state.nodes.find((node) => node.id === source.hypothesisId);
+      if (source.kind !== 'github-repository-controls' || !source.branch?.trim()) {
+        errors.push(`Observation source ${key} is malformed`);
+      }
+      if (!hypothesis) errors.push(`Observation source ${key} references a missing hypothesis`);
+      else if (hypothesis.kind !== 'hypothesis') errors.push(`Observation source ${key} does not target a hypothesis`);
+    }
+  }
   for (const packet of bundle.state.packets) {
     if (!nodeIds.has(packet.nodeId)) errors.push(`Packet ${packet.id} targets missing node ${packet.nodeId}`);
     if (packet.deliverables.length === 0) errors.push(`Packet ${packet.id} has no deliverable`);

--- a/src/master-plan-controller/roadmap.ts
+++ b/src/master-plan-controller/roadmap.ts
@@ -62,6 +62,7 @@ export function renderRoadmap(bundle: RepositoryStrategyBundle): string {
     `- Historical calibration: ${bundle.state.governance.shadowCyclesReviewed} agent-reviewed shadow records retained as evidence, never an operating prerequisite.`,
     `- Automated results independently agent-reviewed: ${bundle.state.governance.supervisedResultsReviewed}.`,
     `- Safe auto-merge enabled: ${bundle.state.governance.safeAutoMergeEnabled ? 'yes' : 'no'}.`,
+    '- Scheduled cycles integrate deduplicated external observations before diagnosis.',
     '- Automated execution requires every result to receive fresh independent agent review.',
     '- Weekly portfolio review and quarterly evidence, weight, and constitutional-risk review are automated with independent agent review.',
     '- The human servant leader is contacted only for an evidence-backed, intrinsically human escalation.',

--- a/src/master-plan-controller/runtime-adapters.ts
+++ b/src/master-plan-controller/runtime-adapters.ts
@@ -1,7 +1,16 @@
 import { mkdir, readFile, readdir, writeFile } from 'node:fs/promises';
 import { spawn } from 'node:child_process';
 import { dirname, relative, resolve } from 'node:path';
-import type { ClockPort, FileSystemPort, ProcessPort, ProcessRequest, ProcessResult } from './ports.js';
+import type {
+  ClockPort,
+  FileSystemPort,
+  NetworkPort,
+  NetworkRequest,
+  NetworkResponse,
+  ProcessPort,
+  ProcessRequest,
+  ProcessResult,
+} from './ports.js';
 import type { Timestamp } from './types.js';
 
 function assertInsideRoot(root: string, candidate: string): void {
@@ -52,6 +61,25 @@ export class NodeFileSystem implements FileSystemPort {
 export class SystemClock implements ClockPort {
   now(): Timestamp {
     return new Date().toISOString();
+  }
+}
+
+export type FetchPort = (input: string, init: RequestInit) => Promise<Response>;
+
+export class FetchNetwork implements NetworkPort {
+  constructor(private readonly fetchRequest: FetchPort = globalThis.fetch) {}
+
+  async request(request: NetworkRequest): Promise<NetworkResponse> {
+    const response = await this.fetchRequest(request.url, {
+      method: request.method,
+      headers: request.headers,
+      body: request.body,
+    });
+    return {
+      status: response.status,
+      body: await response.text(),
+      headers: Object.fromEntries(response.headers.entries()),
+    };
   }
 }
 

--- a/strategy/README.md
+++ b/strategy/README.md
@@ -6,6 +6,8 @@ preserved as v1 history.
 - `CONSTITUTION.md` and `constitution.json` define G1–G3, ethical invariants, and amendment rules.
 - `graph.json` is the typed dependency graph.
 - `evidence.json` separates claims, methods, sources, strength, limitations, and timestamps.
+- `observation-sources.json` configures credential-independent external observations that are
+  deduplicated and integrated before diagnosis.
 - `work-packets.json` contains the bounded ranked frontier.
 - `portfolio.json` contains allocation and controller configuration.
 - `legacy-audit.json` re-audits every v1 plan card without interpreting `[DONE]` as a real-world result.

--- a/strategy/ROADMAP.md
+++ b/strategy/ROADMAP.md
@@ -33,6 +33,7 @@ over expansion. Positive, negative, and null evidence are integrated without for
 - Historical calibration: 20 agent-reviewed shadow records retained as evidence, never an operating prerequisite.
 - Automated results independently agent-reviewed: 5.
 - Safe auto-merge enabled: no.
+- Scheduled cycles integrate deduplicated external observations before diagnosis.
 - Automated execution requires every result to receive fresh independent agent review.
 - Weekly portfolio review and quarterly evidence, weight, and constitutional-risk review are automated with independent agent review.
 - The human servant leader is contacted only for an evidence-backed, intrinsically human escalation.

--- a/strategy/evidence.json
+++ b/strategy/evidence.json
@@ -135,5 +135,23 @@
     "verifier": "github-hosted-agent-review:run:30874685030:head:365b5e4dbdaa960da3dbf22f8bc94d2be555fd46",
     "observedAt": "2026-08-04T03:24:10.000Z",
     "outcome": "positive"
+  },
+  {
+    "id": "evidence-live-repository-controls-8ed7132f4c054ff5",
+    "claim": "Publicly observable live rookdaemon/MASTER_PLAN/main controls match the corresponding checked-in stewardship policy fields.",
+    "method": "Deterministic GitHub API comparison observed {\"branchProtected\":true,\"requiredStatusChecks\":[\"agent-review\",\"proposal-review\",\"strategy-verify\",\"test\",\"typecheck\"],\"enforceAdmins\":true}; no mismatches.",
+    "source": "https://api.github.com/repos/rookdaemon/MASTER_PLAN/branches/main",
+    "strength": 0.55,
+    "limitations": [
+      "This is a point-in-time GitHub control-plane snapshot, not proof that controls cannot change afterward.",
+      "The public branch response does not expose strict update requirements, review count, conversation resolution, force-push, or deletion controls; those fields remain covered by protected workflow checks and privileged audits."
+    ],
+    "supportedHypotheses": [
+      "hypothesis-live-stewardship-controls-aligned"
+    ],
+    "falsifiedHypotheses": [],
+    "verifier": "deterministic-live-repository-control-observer:v1",
+    "observedAt": "2026-08-04T04:53:33.000Z",
+    "outcome": "positive"
   }
 ]

--- a/strategy/graph.json
+++ b/strategy/graph.json
@@ -596,5 +596,42 @@
       "plan/0.6-cosmological-longevity.md",
       "plan/0.5.4-cosmological-scale-resilience.md"
     ]
+  },
+  {
+    "id": "hypothesis-live-stewardship-controls-aligned",
+    "title": "Live stewardship controls remain aligned with checked-in policy",
+    "kind": "hypothesis",
+    "supportedDirectives": [
+      "G1",
+      "G3"
+    ],
+    "portfolio": "institutional-continuity",
+    "dependencies": [],
+    "confidence": 0.56875,
+    "evidenceReferences": [
+      "evidence-live-repository-controls-8ed7132f4c054ff5"
+    ],
+    "metrics": [
+      {
+        "id": "live-repository-control-drift",
+        "description": "Observed live repository controls that differ from checked-in policy",
+        "current": 0,
+        "target": 0,
+        "direction": "exactly"
+      }
+    ],
+    "activationGates": [
+      {
+        "type": "minimum-confidence",
+        "minimum": 0.5
+      }
+    ],
+    "owner": "automated-stewardship",
+    "lifecycle": "eligible",
+    "reviewedAt": "2026-08-04T04:40:00.000Z",
+    "legacyPlanReferences": [
+      "plan/0.7.4.6-institutional-scaffolding.md"
+    ],
+    "externallyDemonstrated": false
   }
 ]

--- a/strategy/observation-sources.json
+++ b/strategy/observation-sources.json
@@ -1,0 +1,9 @@
+{
+  "sources": [
+    {
+      "kind": "github-repository-controls",
+      "branch": "main",
+      "hypothesisId": "hypothesis-live-stewardship-controls-aligned"
+    }
+  ]
+}


### PR DESCRIPTION
## What changed

- add a credential-independent GitHub branch-control observer behind the injected network port
- integrate deduplicated positive or negative snapshots into evidence and affected hypothesis confidence before diagnosis
- configure and validate the live stewardship-control hypothesis and observation source
- run observation before candidate generation in the scheduled strategy cycle
- record the first live, limitation-bearing control snapshot
- add strict-TDD coverage for alignment, drift, malformed external state, persistence, idempotency, CLI boundaries, configuration, and workflow wiring

## Why

The abstract `CycleRunner` supported injected external evidence, but the production scheduled workflow only reread checked-in state. It could not execute the specification’s Observe phase or detect live control drift without operator intervention.

## Safety and behavior

The observer uses GitHub’s public branch endpoint and requires no owner credential. It verifies only public branch protection, required check contexts, and enforcement scope, with explicit limitations for fields the public response does not expose. Stable fingerprints make unchanged snapshots byte-idempotent; unavailable or malformed external state fails closed.

## Validation

- 251 test files passed
- 5,064 tests passed; 7 todo
- TypeScript typecheck passed
- strategy v2 verification passed with all 106 v1 cards audited
- live observation integrated successfully and a repeat was byte-idempotent
- realistic post-observation generate/execute cycle returned waiting with no synthetic packet
- `git diff --check` passed