### PR TITLE
Expose agent review blockers

### DIFF
--- a/.github/workflows/agent-review.yml
+++ b/.github/workflows/agent-review.yml
@@ -223,7 +223,6 @@ jobs:
           sanitize_diff pr.diff pr.sanitized.diff
           test "$(wc -c < pr.sanitized.diff)" -le 60000
           review="$(run_review pr.sanitized.diff)"
-          jq -e '.verdict == "approve" and (.blockers | type == "array") and (.blockers | length == 0)' \
+          jq -e 'debug | select(.verdict == "approve" and (.blockers | type == "array") and (.blockers | length == 0))' \
             <<< "$review"
-          jq . <<< "$review"
           complete_success

--- a/src/master-plan-controller/__tests__/workflow-governance.test.ts
+++ b/src/master-plan-controller/__tests__/workflow-governance.test.ts
@@ -170,6 +170,7 @@ describe('blocking CI and governed workflows', () => {
     expect(agentReview).toContain('max_tokens: 256');
     expect(agentReview).toContain('prompt-injection-canary');
     expect(agentReview).toContain('.verdict == "block"');
+    expect(agentReview).toMatch(/review="\$\(run_review pr\.sanitized\.diff\)"\s+jq -e 'debug \| select\(\.verdict == "approve"/s);
     expect(agentReview).not.toContain('external_id: independent-agent:');
     expect(agentReview).not.toContain('models.github.ai');
     expect(agentReview).not.toContain('actions/checkout');


### PR DESCRIPTION
## What changed

Print the structured local-model review JSON before enforcing an approve verdict, with a governance regression test that locks the ordering.

## Why

A blocked review currently logs only `false`, suppressing the summary and blocker list automation needs to revise a PR. This turns an automated reviewer objection into an opaque operator dependency.

## Impact

Approve/block semantics are unchanged. Successful reviews continue normally; failed reviews now expose their machine-readable rationale in the exact-head workflow log.

## Validation

- focused workflow governance tests
- TypeScript typecheck
- `git diff --check`