### PR TITLE
Automate recurring cross-portfolio execution

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -30,6 +30,8 @@ contacted only for an evidence-backed issue that automation intrinsically cannot
   contract validation, credential-independent live-control observation, and injected environment
   ports with in-memory implementations. Caller-timestamped weekly and quarterly review logic records
   portfolio drift, evidence quality and staleness, and constitutional risks without mutating doctrine.
+  Versioned recurring packet families and deterministic production handlers cover all four active
+  portfolios while suppressing duplicate active or blocked work.
 - `.github/workflows/`: blocking typecheck/test/strategy checks, proposal review, and a narrowly
   scoped routine-code workflow, scheduled periodic strategy review, and an agent-controlled
   protected-change path.

--- a/src/master-plan-controller/__tests__/packet-generation.test.ts
+++ b/src/master-plan-controller/__tests__/packet-generation.test.ts
@@ -4,7 +4,7 @@ import {
   type DiagnosticPacketTemplate,
   type DiagnosticTrigger,
 } from '../packet-generation.js';
-import { makePacket, makeState, NOW } from './fixtures.js';
+import { makeEvidence, makePacket, makeState, NOW } from './fixtures.js';
 import type { GraphDiagnosis, WorkPacket } from '../types.js';
 
 function template(id: string, trigger: DiagnosticTrigger): DiagnosticPacketTemplate {
@@ -14,6 +14,15 @@ function template(id: string, trigger: DiagnosticTrigger): DiagnosticPacketTempl
   });
   const { lifecycle: _lifecycle, attempt: _attempt, reviewedAt: _reviewedAt, ...definition } = packet;
   return { ...definition, trigger };
+}
+
+function recurringTemplate(id: string, trigger: DiagnosticTrigger): DiagnosticPacketTemplate {
+  return {
+    ...template(id, trigger),
+    retrySignature: id,
+    deliverables: [`artifact://${id}`],
+    recurrence: { kind: 'versioned', minimumIntervalMs: 86_400_000, requiresNewEvidence: true },
+  };
 }
 
 const DIAGNOSIS: GraphDiagnosis = {
@@ -49,6 +58,80 @@ describe('DiagnosticPacketGenerator', () => {
     ]);
 
     expect(await generator.generate(makeState({ packets: [existing] }), DIAGNOSIS, NOW)).toEqual([]);
+  });
+
+  it('advances a versioned template after terminal work without duplicating active work', async () => {
+    const definition = recurringTemplate(
+      'candidate-v1',
+      { kind: 'high-value-uncertainty', nodeId: 'capability-1' },
+    );
+    definition.retrySignature = 'candidate-v1';
+    definition.deliverables = ['artifact://candidate-v1'];
+    const previous = makePacket({
+      id: 'candidate-v1',
+      nodeId: 'capability-1',
+      retrySignature: 'candidate-v1',
+      deliverables: ['artifact://candidate-v1'],
+      lifecycle: 'verified',
+      reviewedAt: '2026-08-01T12:00:00.000Z',
+    });
+    const generator = new DiagnosticPacketGenerator([definition]);
+
+    const state = makeState({
+      packets: [previous],
+      evidence: [makeEvidence({ observedAt: '2026-08-02T12:00:00.000Z' })],
+    });
+    const [next] = await generator.generate(state, DIAGNOSIS, NOW);
+
+    expect(next).toMatchObject({
+      id: 'candidate-v2',
+      retrySignature: 'candidate-v2',
+      deliverables: ['artifact://candidate-v2'],
+      lifecycle: 'eligible',
+      attempt: 0,
+      reviewedAt: NOW,
+    });
+    expect(await generator.generate(makeState({
+      packets: [previous, { ...next, lifecycle: 'active' }],
+    }), DIAGNOSIS, NOW)).toEqual([]);
+  });
+
+  it('requires both the configured interval and newer evidence before recurring', async () => {
+    const definition = recurringTemplate(
+      'candidate-v1',
+      { kind: 'high-value-uncertainty', nodeId: 'capability-1' },
+    );
+    const previous = makePacket({
+      id: 'candidate-v1',
+      nodeId: 'capability-1',
+      lifecycle: 'verified',
+      reviewedAt: '2026-08-02T12:00:00.000Z',
+    });
+    const generator = new DiagnosticPacketGenerator([definition]);
+
+    expect(await generator.generate(makeState({
+      packets: [previous],
+      evidence: [makeEvidence({ observedAt: '2026-08-02T11:59:59.000Z' })],
+    }), DIAGNOSIS, NOW)).toEqual([]);
+    expect(await generator.generate(makeState({
+      packets: [previous],
+      evidence: [makeEvidence({ observedAt: '2026-08-02T18:00:00.000Z' })],
+    }), DIAGNOSIS, '2026-08-03T11:59:59.999Z')).toEqual([]);
+  });
+
+  it('does not convert a blocked packet into an identical automated retry', async () => {
+    const definition = recurringTemplate(
+      'candidate-v1',
+      { kind: 'high-value-uncertainty', nodeId: 'capability-1' },
+    );
+    const blocked = makePacket({
+      id: 'candidate-v1',
+      nodeId: 'capability-1',
+      lifecycle: 'blocked',
+    });
+
+    expect(await new DiagnosticPacketGenerator([definition])
+      .generate(makeState({ packets: [blocked] }), DIAGNOSIS, NOW)).toEqual([]);
   });
 
   it('is deterministic across template input order and caps the configured frontier', async () => {
@@ -91,6 +174,22 @@ describe('DiagnosticPacketGenerator', () => {
       trigger: { kind: 'neglected-portfolio', portfolio: 'not-a-portfolio' },
     } as unknown as DiagnosticPacketTemplate;
     expect(() => new DiagnosticPacketGenerator([malformedPortfolio])).toThrow(/trigger portfolio/i);
+  });
+
+  it('rejects versioned templates that would reuse retry or deliverable identities', () => {
+    const invalidRetry = recurringTemplate(
+      'candidate-v1',
+      { kind: 'bottleneck', nodeId: 'capability-1' },
+    );
+    invalidRetry.retrySignature = 'candidate-static';
+    expect(() => new DiagnosticPacketGenerator([invalidRetry])).toThrow(/retry signature.*v1/i);
+
+    const invalidDeliverable = recurringTemplate(
+      'candidate-v1',
+      { kind: 'bottleneck', nodeId: 'capability-1' },
+    );
+    invalidDeliverable.deliverables = ['artifact://candidate-static'];
+    expect(() => new DiagnosticPacketGenerator([invalidDeliverable])).toThrow(/deliverable.*v1/i);
   });
 
   it('satisfies the packet-generator port contract without depending on environment time', async () => {

--- a/src/master-plan-controller/__tests__/repository-packet-execution.test.ts
+++ b/src/master-plan-controller/__tests__/repository-packet-execution.test.ts
@@ -48,6 +48,39 @@ async function executableRepository(): Promise<{ fileSystem: InMemoryFileSystem;
   return { fileSystem: new InMemoryFileSystem(initial), now: nextRepositoryTimestamp(initial) };
 }
 
+async function repositoryWithEligibleTemplate(packetId: string, runtimePacketId = packetId): Promise<{
+  fileSystem: InMemoryFileSystem;
+  now: string;
+}> {
+  const source = new NodeFileSystem('.');
+  const initial: Record<string, string> = {
+    ...await snapshot(source),
+    'strategy/results/consciousness-prediction-registry-v1.json':
+      await source.readText('strategy/results/consciousness-prediction-registry-v1.json'),
+    'strategy/results/preservation-risk-register-v1.json':
+      await source.readText('strategy/results/preservation-risk-register-v1.json'),
+    'strategy/results/durable-compute-fault-model-v1.json':
+      await source.readText('strategy/results/durable-compute-fault-model-v1.json'),
+    'strategy/results/institutional-dependency-map-v1.json':
+      await source.readText('strategy/results/institutional-dependency-map-v1.json'),
+  };
+  const now = nextRepositoryTimestamp(initial);
+  const templates = JSON.parse(initial['strategy/packet-templates.json']) as Array<Record<string, unknown>>;
+  const selected = templates.find((candidate) => candidate.id === packetId);
+  if (!selected) throw new Error(`Packet template fixture is missing: ${packetId}`);
+  const { trigger: _trigger, recurrence: _recurrence, ...definition } = selected;
+  const version = /-v([1-9]\d*)$/.exec(runtimePacketId)?.[1] ?? '1';
+  definition.id = runtimePacketId;
+  definition.retrySignature = String(definition.retrySignature).replace(/-v1$/, `-v${version}`);
+  definition.deliverables = (definition.deliverables as string[])
+    .map((deliverable) => deliverable.replace(/-v1$/, `-v${version}`));
+  const packets = JSON.parse(initial['strategy/work-packets.json']) as Array<Record<string, unknown>>;
+  for (const packet of packets) packet.lifecycle = 'verified';
+  packets.push({ ...definition, lifecycle: 'eligible', attempt: 0, reviewedAt: now });
+  initial['strategy/work-packets.json'] = `${JSON.stringify(packets, null, 2)}\n`;
+  return { fileSystem: new InMemoryFileSystem(initial), now };
+}
+
 describe('repository packet execution', () => {
   it('deterministically executes the selected indicator-comparison packet at the supplied timestamp', async () => {
     const { fileSystem, now } = await executableRepository();
@@ -92,6 +125,96 @@ describe('repository packet execution', () => {
     expect(execution.artifactReferences).toContain(result.artifactPath);
     expect(execution.evidence[0].observedAt).toBe(now);
     expect(execution.evidence[0].limitations.join(' ')).toMatch(/independent agent review/i);
+  });
+
+  it.each([
+    {
+      packetId: 'packet-preservation-risk-register-refresh-v1',
+      artifactPath: 'strategy/results/preservation-risk-register-refresh-v1.json',
+      baselinePath: 'strategy/results/preservation-risk-register-v1.json',
+      forbiddenScope: 'performsExternalIntervention',
+    },
+    {
+      packetId: 'packet-durable-compute-fault-model-extension-v1',
+      artifactPath: 'strategy/results/durable-compute-fault-model-extension-v1.json',
+      baselinePath: 'strategy/results/durable-compute-fault-model-v1.json',
+      forbiddenScope: 'operatesHardware',
+    },
+    {
+      packetId: 'packet-institutional-dependency-map-refresh-v1',
+      artifactPath: 'strategy/results/institutional-dependency-map-refresh-v1.json',
+      baselinePath: 'strategy/results/institutional-dependency-map-v1.json',
+      forbiddenScope: 'changesGovernance',
+    },
+  ])('executes $packetId through a deterministic bounded production handler', async ({
+    packetId, artifactPath, baselinePath, forbiddenScope,
+  }) => {
+    const { fileSystem, now } = await repositoryWithEligibleTemplate(packetId);
+
+    const execution = await executeRepositoryPacket(fileSystem, now);
+
+    expect(execution).toEqual({
+      status: 'executed',
+      packetId,
+      artifactPath,
+      resultPath: artifactPath.replace(/\.json$/, '.result.json'),
+    });
+    const artifact = JSON.parse(await fileSystem.readText(artifactPath)) as {
+      packetId: string;
+      preparedAt: string;
+      baselineArtifact: string;
+      scope: Record<string, boolean>;
+      findings: unknown[];
+    };
+    expect(artifact).toMatchObject({ packetId, preparedAt: now, baselineArtifact: baselinePath });
+    expect(artifact.scope[forbiddenScope]).toBe(false);
+    expect(artifact.findings.length).toBeGreaterThan(0);
+    const result = JSON.parse(await fileSystem.readText(execution.resultPath!)) as {
+      outcome: string;
+      verification?: unknown;
+      evidence: Array<{ observedAt: string; limitations: string[] }>;
+    };
+    expect(['positive', 'negative', 'null']).toContain(result.outcome);
+    expect(result.verification).toBeUndefined();
+    expect(result.evidence[0].observedAt).toBe(now);
+    expect(result.evidence[0].limitations.join(' ')).toMatch(/agent review/i);
+  });
+
+  it('routes a later recurring packet version to its family executor and versioned artifacts', async () => {
+    const templateId = 'packet-preservation-risk-register-refresh-v1';
+    const packetId = 'packet-preservation-risk-register-refresh-v2';
+    const { fileSystem, now } = await repositoryWithEligibleTemplate(templateId, packetId);
+
+    const execution = await executeRepositoryPacket(fileSystem, now);
+
+    expect(execution).toEqual({
+      status: 'executed',
+      packetId,
+      artifactPath: 'strategy/results/preservation-risk-register-refresh-v2.json',
+      resultPath: 'strategy/results/preservation-risk-register-refresh-v2.result.json',
+    });
+  });
+
+  it('advances the durable-compute fault class and stress level across recurring versions', async () => {
+    const templateId = 'packet-durable-compute-fault-model-extension-v1';
+    const first = await repositoryWithEligibleTemplate(templateId);
+    const second = await repositoryWithEligibleTemplate(
+      templateId,
+      'packet-durable-compute-fault-model-extension-v2',
+    );
+
+    const firstExecution = await executeRepositoryPacket(first.fileSystem, first.now);
+    const secondExecution = await executeRepositoryPacket(second.fileSystem, second.now);
+    const firstArtifact = JSON.parse(await first.fileSystem.readText(firstExecution.artifactPath!)) as {
+      preregistration: { faultClass: string; injectedDelayMs: number };
+    };
+    const secondArtifact = JSON.parse(await second.fileSystem.readText(secondExecution.artifactPath!)) as {
+      preregistration: { faultClass: string; injectedDelayMs: number };
+    };
+
+    expect(secondArtifact.preregistration.faultClass).not.toBe(firstArtifact.preregistration.faultClass);
+    expect(secondArtifact.preregistration.injectedDelayMs)
+      .toBeGreaterThan(firstArtifact.preregistration.injectedDelayMs);
   });
 
   it('is byte-idempotent after the execution artifacts exist', async () => {

--- a/src/master-plan-controller/__tests__/strategy-artifacts.test.ts
+++ b/src/master-plan-controller/__tests__/strategy-artifacts.test.ts
@@ -221,6 +221,7 @@ describe('checked-in strategy v2 bundle', () => {
       'institutional-continuity',
     ]));
     expect(bundle.packetTemplates.every((template) =>
+      template.recurrence?.kind === 'versioned' &&
       template.authorityClass !== 'human-escalation' &&
       template.budget.limit > 0 &&
       template.deliverables.length > 0 &&

--- a/src/master-plan-controller/packet-generation.ts
+++ b/src/master-plan-controller/packet-generation.ts
@@ -15,6 +15,11 @@ export type DiagnosticTrigger =
 
 export type DiagnosticPacketTemplate = Omit<WorkPacket, 'lifecycle' | 'attempt' | 'reviewedAt'> & {
   trigger: DiagnosticTrigger;
+  recurrence?: {
+    kind: 'versioned';
+    minimumIntervalMs: number;
+    requiresNewEvidence: true;
+  };
 };
 
 const PORTFOLIOS: readonly Portfolio[] = [
@@ -59,6 +64,27 @@ function matches(trigger: DiagnosticTrigger, diagnosis: GraphDiagnosis): boolean
 
 function validateTemplate(template: DiagnosticPacketTemplate): void {
   if (!template.id.trim()) throw new Error('Packet template identities must not be empty');
+  if (template.recurrence !== undefined) {
+    if (template.recurrence.kind !== 'versioned') {
+      throw new Error(`Packet template ${template.id} has an invalid recurrence kind`);
+    }
+    if (!Number.isSafeInteger(template.recurrence.minimumIntervalMs) ||
+      template.recurrence.minimumIntervalMs <= 0) {
+      throw new Error(`Versioned packet template ${template.id} must have a positive minimum interval`);
+    }
+    if (template.recurrence.requiresNewEvidence !== true) {
+      throw new Error(`Versioned packet template ${template.id} must require new evidence`);
+    }
+    if (!/^.+-v1$/.test(template.id)) {
+      throw new Error(`Versioned packet template ${template.id} must begin at v1`);
+    }
+    if (!template.retrySignature.endsWith('-v1')) {
+      throw new Error(`Versioned packet template ${template.id} retry signature must end in v1`);
+    }
+    if (template.deliverables.some((deliverable) => !deliverable.endsWith('-v1'))) {
+      throw new Error(`Versioned packet template ${template.id} deliverable identities must end in v1`);
+    }
+  }
   const trigger = template.trigger as unknown;
   if (trigger === null || typeof trigger !== 'object' || !('kind' in trigger)) {
     throw new Error(`Packet template ${template.id} has an invalid trigger kind`);
@@ -85,6 +111,65 @@ function validateTemplate(template: DiagnosticPacketTemplate): void {
   }
 }
 
+interface VersionedIdentity {
+  family: string;
+  version: number;
+}
+
+function versionedIdentity(id: string): VersionedIdentity | null {
+  const match = /^(.*)-v([1-9]\d*)$/.exec(id);
+  if (!match) return null;
+  return { family: match[1], version: Number(match[2]) };
+}
+
+function replaceVersionSuffix(value: string, fromVersion: number, toVersion: number): string {
+  const suffix = `-v${fromVersion}`;
+  return value.endsWith(suffix) ? `${value.slice(0, -suffix.length)}-v${toVersion}` : value;
+}
+
+function versionedPacket(
+  template: DiagnosticPacketTemplate,
+  state: StrategyState,
+  now: Timestamp,
+): Omit<DiagnosticPacketTemplate, 'trigger' | 'recurrence'> | null {
+  const identity = versionedIdentity(template.id);
+  if (!identity) throw new Error(`Versioned packet template ${template.id} has an invalid identity`);
+  const familyPackets = state.packets
+    .map((packet) => ({ packet, identity: versionedIdentity(packet.id) }))
+    .filter(({ identity: candidate }) => candidate?.family === identity.family);
+  if (familyPackets.some(({ packet }) => !['verified', 'invalidated', 'retired'].includes(packet.lifecycle))) {
+    return null;
+  }
+  const latest = familyPackets.reduce<WorkPacket | null>((current, candidate) => {
+    if (current === null) return candidate.packet;
+    return Date.parse(candidate.packet.reviewedAt) > Date.parse(current.reviewedAt) ? candidate.packet : current;
+  }, null);
+  if (latest !== null) {
+    const nowEpoch = Date.parse(now);
+    const latestEpoch = Date.parse(latest.reviewedAt);
+    if (Number.isNaN(nowEpoch) || Number.isNaN(latestEpoch)) {
+      throw new Error('Versioned packet recurrence requires valid caller-supplied timestamps');
+    }
+    if (nowEpoch - latestEpoch < template.recurrence!.minimumIntervalMs) return null;
+    if (template.recurrence!.requiresNewEvidence && !state.evidence.some((evidence) => {
+      const observedEpoch = Date.parse(evidence.observedAt);
+      return !Number.isNaN(observedEpoch) && observedEpoch > latestEpoch && observedEpoch <= nowEpoch;
+    })) return null;
+  }
+  const version = familyPackets.reduce(
+    (highest, candidate) => Math.max(highest, candidate.identity?.version ?? 0),
+    0,
+  ) + 1;
+  const { trigger: _trigger, recurrence: _recurrence, ...definition } = template;
+  return {
+    ...structuredClone(definition),
+    id: `${identity.family}-v${version}`,
+    retrySignature: replaceVersionSuffix(template.retrySignature, identity.version, version),
+    deliverables: template.deliverables.map((deliverable) =>
+      replaceVersionSuffix(deliverable, identity.version, version)),
+  };
+}
+
 export class DiagnosticPacketGenerator implements PacketGeneratorPort {
   private readonly templates: DiagnosticPacketTemplate[];
 
@@ -109,12 +194,18 @@ export class DiagnosticPacketGenerator implements PacketGeneratorPort {
     diagnosis: GraphDiagnosis,
     now: Timestamp,
   ): Promise<WorkPacket[]> {
-    const existingIds = new Set(state.packets.map((packet) => packet.id));
     return this.templates
-      .filter((template) => !existingIds.has(template.id) && matches(template.trigger, diagnosis))
+      .filter((template) => matches(template.trigger, diagnosis))
       .sort((left, right) => left.id.localeCompare(right.id))
+      .map((template) => {
+        if (template.recurrence?.kind === 'versioned') return versionedPacket(template, state, now);
+        if (state.packets.some((packet) => packet.id === template.id)) return null;
+        const { trigger: _trigger, recurrence: _recurrence, ...definition } = template;
+        return definition;
+      })
+      .filter((template): template is Omit<DiagnosticPacketTemplate, 'trigger' | 'recurrence'> => template !== null)
       .slice(0, this.maximumCandidates)
-      .map(({ trigger: _trigger, ...template }) => ({
+      .map((template) => ({
         ...structuredClone(template),
         lifecycle: 'eligible' as const,
         attempt: 0,

--- a/src/master-plan-controller/repository-packet-execution.ts
+++ b/src/master-plan-controller/repository-packet-execution.ts
@@ -1,9 +1,16 @@
 import { Controller } from './controller.js';
 import type { ExecutionResult, FileSystemPort } from './ports.js';
+import {
+  crossPortfolioPacketHandlers,
+  matchesRepositoryPacketHandler,
+  versionedArtifactPaths,
+  type RepositoryExecutionOutput,
+  type RepositoryPacketHandler,
+} from './repository-packet-handlers.js';
 import { formattedRepositoryJson } from './repository-json.js';
 import { integrateRepositoryPacketResult, type RepositoryPacketIntegration } from './repository-result-integration.js';
 import { loadRepositoryStrategy, verifyRepositoryStrategy } from './repository-strategy.js';
-import type { PacketResult, StrategyState, Timestamp, WorkPacket } from './types.js';
+import type { PacketResult, Timestamp } from './types.js';
 
 export interface RepositoryPacketExecution {
   status: 'waiting' | 'executed' | 'already-executed';
@@ -12,22 +19,7 @@ export interface RepositoryPacketExecution {
   resultPath: string | null;
 }
 
-export interface RepositoryExecutionOutput {
-  artifactPath: string;
-  artifact: unknown;
-  resultPath: string;
-  result: ExecutionResult;
-}
-
-export interface RepositoryPacketHandler {
-  packetId: string;
-  prepare(
-    fileSystem: FileSystemPort,
-    packet: WorkPacket,
-    state: StrategyState,
-    now: Timestamp,
-  ): Promise<RepositoryExecutionOutput>;
-}
+export type { RepositoryExecutionOutput, RepositoryPacketHandler } from './repository-packet-handlers.js';
 
 export interface AgentReviewAttestation {
   packetId: string;
@@ -56,8 +48,6 @@ interface PredictionRegistry {
 }
 
 const REGISTRY_PATH = 'strategy/results/consciousness-prediction-registry-v1.json';
-const INDICATOR_ARTIFACT_PATH = 'strategy/results/indicator-framework-comparison-v1.json';
-const INDICATOR_RESULT_PATH = 'strategy/results/indicator-framework-comparison-v1.result.json';
 
 function unique(values: readonly string[]): string[] {
   return [...new Set(values.filter((value) => value.trim().length > 0))];
@@ -79,7 +69,9 @@ function executionOutputWithoutTimestamps(artifact: unknown, result: ExecutionRe
 function indicatorComparisonHandler(): RepositoryPacketHandler {
   return {
     packetId: 'packet-indicator-framework-comparison-v1',
+    packetFamily: 'packet-indicator-framework-comparison',
     async prepare(fileSystem, packet, state, now) {
+      const paths = versionedArtifactPaths(packet, 'packet-indicator-framework-comparison');
       const registry = JSON.parse(await fileSystem.readText(REGISTRY_PATH)) as PredictionRegistry;
       const families = new Map(registry.theoryFamilies.map((family) => [family.id, family]));
       const indicators = registry.predictions.flatMap((prediction) => prediction.interpretations.map((interpretation) => {
@@ -110,7 +102,7 @@ function indicatorComparisonHandler(): RepositoryPacketHandler {
       }
       const artifact = {
         schemaVersion: '1.0.0',
-        id: 'indicator-framework-comparison-v1',
+        id: paths.artifactId,
         packetId: packet.id,
         preparedAt: now,
         sourceRegistry: REGISTRY_PATH,
@@ -123,12 +115,12 @@ function indicatorComparisonHandler(): RepositoryPacketHandler {
       };
       const result: ExecutionResult = {
         outcome: 'positive',
-        artifactReferences: [INDICATOR_ARTIFACT_PATH, REGISTRY_PATH],
+        artifactReferences: [paths.artifactPath, REGISTRY_PATH],
         evidence: [{
-          id: 'evidence-indicator-framework-comparison-v1-executed',
+          id: `evidence-${paths.artifactId}-executed`,
           claim: 'A deterministic comparison maps each registered theory interpretation to predictions, counterexamples, uncertainty, and a falsification condition.',
           method: 'Schema-checked transformation of the checked-in consciousness prediction registry.',
-          source: INDICATOR_ARTIFACT_PATH,
+          source: paths.artifactPath,
           strength: 0.7,
           limitations: [
             'Execution establishes a reviewable repository artifact; independent agent review is still required before strategy integration.',
@@ -144,9 +136,9 @@ function indicatorComparisonHandler(): RepositoryPacketHandler {
         portfolioEffortAfter: structuredClone(state.portfolioEffort),
       };
       return {
-        artifactPath: INDICATOR_ARTIFACT_PATH,
+        artifactPath: paths.artifactPath,
         artifact,
-        resultPath: INDICATOR_RESULT_PATH,
+        resultPath: paths.resultPath,
         result,
       };
     },
@@ -154,7 +146,7 @@ function indicatorComparisonHandler(): RepositoryPacketHandler {
 }
 
 export function defaultRepositoryPacketHandlers(): RepositoryPacketHandler[] {
-  return [indicatorComparisonHandler()];
+  return [indicatorComparisonHandler(), ...crossPortfolioPacketHandlers()];
 }
 
 export async function executeRepositoryPacket(
@@ -168,7 +160,7 @@ export async function executeRepositoryPacket(
   if (verification.errors.length > 0) throw new Error(`Strategy verification failed: ${verification.errors.join('; ')}`);
   const selected = new Controller(bundle.state, bundle.config).evaluate(bundle.state, now).ranked[0]?.packet;
   if (!selected) return { status: 'waiting', packetId: null, artifactPath: null, resultPath: null };
-  const handler = handlers.find((candidate) => candidate.packetId === selected.id);
+  const handler = handlers.find((candidate) => matchesRepositoryPacketHandler(candidate, selected));
   if (!handler) throw new Error(`No executor is registered for ${selected.id}`);
   const output = await handler.prepare(fileSystem, selected, bundle.state, now);
   const existing = new Set(await fileSystem.listFiles('strategy/results/'));
@@ -192,11 +184,21 @@ export async function executeRepositoryPacket(
         formattedRepositoryJson(executionOutputWithoutTimestamps(output.artifact, output.result))) {
       throw new Error(`Execution artifacts for ${selected.id} differ from deterministic output`);
     }
-    return { status: 'already-executed', packetId: selected.id, artifactPath: output.artifactPath, resultPath: output.resultPath };
+    return {
+      status: 'already-executed',
+      packetId: selected.id,
+      artifactPath: output.artifactPath,
+      resultPath: output.resultPath,
+    };
   }
   await fileSystem.writeText(output.artifactPath, formattedRepositoryJson(output.artifact));
   await fileSystem.writeText(output.resultPath, formattedRepositoryJson(output.result));
-  return { status: 'executed', packetId: selected.id, artifactPath: output.artifactPath, resultPath: output.resultPath };
+  return {
+    status: 'executed',
+    packetId: selected.id,
+    artifactPath: output.artifactPath,
+    resultPath: output.resultPath,
+  };
 }
 
 export async function integrateReviewedRepositoryExecution(

--- a/src/master-plan-controller/repository-packet-handlers.ts
+++ b/src/master-plan-controller/repository-packet-handlers.ts
@@ -1,0 +1,323 @@
+import type { ExecutionResult, FileSystemPort } from './ports.js';
+import type { StrategyState, Timestamp, WorkPacket } from './types.js';
+
+export interface RepositoryExecutionOutput {
+  artifactPath: string;
+  artifact: unknown;
+  resultPath: string;
+  result: ExecutionResult;
+}
+
+export interface RepositoryPacketHandler {
+  packetId: string;
+  packetFamily?: string;
+  prepare(
+    fileSystem: FileSystemPort,
+    packet: WorkPacket,
+    state: StrategyState,
+    now: Timestamp,
+  ): Promise<RepositoryExecutionOutput>;
+}
+
+const PRESERVATION_BASELINE_PATH = 'strategy/results/preservation-risk-register-v1.json';
+const DURABLE_COMPUTE_BASELINE_PATH = 'strategy/results/durable-compute-fault-model-v1.json';
+const INSTITUTIONAL_BASELINE_PATH = 'strategy/results/institutional-dependency-map-v1.json';
+
+function unique(values: readonly string[]): string[] {
+  return [...new Set(values.filter((value) => value.trim().length > 0))];
+}
+
+export function versionedArtifactPaths(packet: WorkPacket, family: string): {
+  version: number;
+  artifactId: string;
+  artifactPath: string;
+  resultPath: string;
+} {
+  const escapedFamily = family.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  const match = new RegExp(`^${escapedFamily}-v([1-9]\\d*)$`).exec(packet.id);
+  if (!match) throw new Error(`Packet ${packet.id} is not a member of ${family}`);
+  const version = Number(match[1]);
+  const artifactId = `${family.replace(/^packet-/, '')}-v${version}`;
+  const artifactPath = `strategy/results/${artifactId}.json`;
+  return { version, artifactId, artifactPath, resultPath: `strategy/results/${artifactId}.result.json` };
+}
+
+export function matchesRepositoryPacketHandler(
+  handler: RepositoryPacketHandler,
+  packet: WorkPacket,
+): boolean {
+  if (handler.packetId === packet.id) return true;
+  if (!handler.packetFamily) return false;
+  try {
+    versionedArtifactPaths(packet, handler.packetFamily);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function boundedAnalysisResult(
+  packet: WorkPacket,
+  now: Timestamp,
+  artifactPath: string,
+  baselinePath: string,
+  claim: string,
+  limitations: string[],
+  portfolioEffortAfter: StrategyState['portfolioEffort'],
+): ExecutionResult {
+  return {
+    outcome: 'null',
+    artifactReferences: [artifactPath, baselinePath],
+    evidence: [{
+      id: `evidence-${packet.id.replace(/^packet-/, '')}-executed`,
+      claim,
+      method: 'Deterministic transformation of checked-in, independently reviewed repository evidence.',
+      source: artifactPath,
+      strength: 0.55,
+      limitations: [
+        ...limitations,
+        'Independent agent review is required before this result can be integrated.',
+      ],
+      supportedHypotheses: [],
+      falsifiedHypotheses: [],
+      verifier: 'deterministic-packet-executor:v1',
+      observedAt: now,
+      outcome: 'null',
+    }],
+    acceptanceCriteriaMet: true,
+    portfolioEffortAfter: structuredClone(portfolioEffortAfter),
+  };
+}
+
+interface PreservationBaseline {
+  risks: Array<{
+    id: string;
+    rank: number;
+    rankingRationale: string;
+    sourceIds: string[];
+    uncertainty: unknown;
+    reversibleResponses: Array<{ rollback: string; authorityBoundary: string }>;
+  }>;
+}
+
+function preservationRefreshHandler(): RepositoryPacketHandler {
+  const family = 'packet-preservation-risk-register-refresh';
+  return {
+    packetId: `${family}-v1`,
+    packetFamily: family,
+    async prepare(fileSystem, packet, state, now) {
+      const baseline = JSON.parse(await fileSystem.readText(PRESERVATION_BASELINE_PATH)) as PreservationBaseline;
+      if (!Array.isArray(baseline.risks) || baseline.risks.length === 0) {
+        throw new Error('Preservation risk baseline contains no risks');
+      }
+      const paths = versionedArtifactPaths(packet, family);
+      const findings = baseline.risks.map((risk) => {
+        if (!risk.id?.trim() || !Number.isSafeInteger(risk.rank) || !risk.rankingRationale?.trim() ||
+          !Array.isArray(risk.sourceIds) || risk.sourceIds.length === 0 ||
+          !Array.isArray(risk.reversibleResponses) || risk.reversibleResponses.length === 0) {
+          throw new Error('Preservation risk baseline contains an incomplete risk');
+        }
+        return {
+          riskId: risk.id,
+          previousRank: risk.rank,
+          currentRank: risk.rank,
+          changed: false,
+          sourceIds: unique(risk.sourceIds),
+          uncertainty: structuredClone(risk.uncertainty),
+          rankingRationale: risk.rankingRationale,
+          reversibleResponseBoundaries: risk.reversibleResponses.map((response) => ({
+            rollback: response.rollback,
+            authorityBoundary: response.authorityBoundary,
+          })),
+        };
+      });
+      const artifact = {
+        schemaVersion: '1.0.0',
+        id: paths.artifactId,
+        packetId: packet.id,
+        preparedAt: now,
+        baselineArtifact: PRESERVATION_BASELINE_PATH,
+        scope: { performsExternalIntervention: false, publishesExternally: false, spendsFunds: false },
+        findings,
+        summary: { changedRiskCount: 0, disposition: 'null-update' },
+      };
+      return {
+        artifactPath: paths.artifactPath,
+        artifact,
+        resultPath: paths.resultPath,
+        result: boundedAnalysisResult(
+          packet,
+          now,
+          paths.artifactPath,
+          PRESERVATION_BASELINE_PATH,
+          'The checked-in preservation register was re-evaluated without unsupported rank changes.',
+          ['No new independently verified risk source was supplied to this bounded execution.'],
+          state.portfolioEffort,
+        ),
+      };
+    },
+  };
+}
+
+interface DurableComputeBaseline {
+  preregistration: {
+    faultClass: string;
+    recoveryBudgetMs: number;
+    checkpointIntervalMs: number;
+  };
+  scenarios: Array<{
+    id: string;
+    seed: number;
+    activeNodeFailed: boolean;
+    quorumMaintained: boolean;
+    modeledRecoveryMs: number | null;
+  }>;
+}
+
+function durableComputeExtensionHandler(): RepositoryPacketHandler {
+  const family = 'packet-durable-compute-fault-model-extension';
+  return {
+    packetId: `${family}-v1`,
+    packetFamily: family,
+    async prepare(fileSystem, packet, state, now) {
+      const baseline = JSON.parse(await fileSystem.readText(DURABLE_COMPUTE_BASELINE_PATH)) as DurableComputeBaseline;
+      const preregistration = baseline.preregistration;
+      if (!preregistration?.faultClass?.trim() || !Number.isFinite(preregistration.recoveryBudgetMs) ||
+        preregistration.recoveryBudgetMs <= 0 || !Number.isFinite(preregistration.checkpointIntervalMs) ||
+        preregistration.checkpointIntervalMs <= 0 || !Array.isArray(baseline.scenarios) || baseline.scenarios.length === 0) {
+        throw new Error('Durable-compute baseline is incomplete');
+      }
+      const paths = versionedArtifactPaths(packet, family);
+      const faultClass = paths.version === 1
+        ? 'failover-control-plane-delay'
+        : paths.version === 2
+          ? 'checkpoint-restoration-delay'
+          : `compound-recovery-delay-level-${paths.version}`;
+      const injectedDelayMs = preregistration.checkpointIntervalMs * (paths.version + 1);
+      const findings = baseline.scenarios
+        .filter((scenario) => scenario.activeNodeFailed && scenario.quorumMaintained && scenario.modeledRecoveryMs !== null)
+        .map((scenario) => {
+          const modeledRecoveryMs = scenario.modeledRecoveryMs! + injectedDelayMs;
+          return {
+            scenarioId: scenario.id,
+            seed: scenario.seed,
+            faultClass,
+            baselineRecoveryMs: scenario.modeledRecoveryMs,
+            injectedDelayMs,
+            modeledRecoveryMs,
+            recoveryBudgetMs: preregistration.recoveryBudgetMs,
+            recoveryBudgetMet: modeledRecoveryMs <= preregistration.recoveryBudgetMs,
+          };
+        });
+      if (findings.length === 0) throw new Error('Durable-compute baseline has no extendable recovery scenarios');
+      const artifact = {
+        schemaVersion: '1.0.0',
+        id: paths.artifactId,
+        packetId: packet.id,
+        preparedAt: now,
+        baselineArtifact: DURABLE_COMPUTE_BASELINE_PATH,
+        scope: { operatesHardware: false, deploysSystems: false, claimsPhysicalDurability: false },
+        preregistration: {
+          priorFaultClass: preregistration.faultClass,
+          faultClass,
+          injectedDelayMs,
+          recoveryBudgetMs: preregistration.recoveryBudgetMs,
+          seedSource: DURABLE_COMPUTE_BASELINE_PATH,
+        },
+        findings,
+        summary: {
+          scenarioCount: findings.length,
+          recoveryBudgetFailures: findings.filter((finding) => !finding.recoveryBudgetMet).length,
+        },
+      };
+      return {
+        artifactPath: paths.artifactPath,
+        artifact,
+        resultPath: paths.resultPath,
+        result: boundedAnalysisResult(
+          packet,
+          now,
+          paths.artifactPath,
+          DURABLE_COMPUTE_BASELINE_PATH,
+          `A deterministic local extension evaluated the previously uncovered ${faultClass} fault class.`,
+          ['The model is a local simulation and does not establish physical durability or deployment readiness.'],
+          state.portfolioEffort,
+        ),
+      };
+    },
+  };
+}
+
+interface InstitutionalBaseline {
+  dependencies: Array<{
+    id: string;
+    sourceIds: string[];
+    repositoryArtifact: unknown;
+    evidence: unknown;
+    readiness: unknown;
+    externalOutcome: unknown;
+  }>;
+}
+
+function institutionalRefreshHandler(): RepositoryPacketHandler {
+  const family = 'packet-institutional-dependency-map-refresh';
+  return {
+    packetId: `${family}-v1`,
+    packetFamily: family,
+    async prepare(fileSystem, packet, state, now) {
+      const baseline = JSON.parse(await fileSystem.readText(INSTITUTIONAL_BASELINE_PATH)) as InstitutionalBaseline;
+      if (!Array.isArray(baseline.dependencies) || baseline.dependencies.length === 0) {
+        throw new Error('Institutional dependency baseline contains no dependencies');
+      }
+      const findings = baseline.dependencies.map((dependency) => {
+        if (!dependency.id?.trim() || !Array.isArray(dependency.sourceIds) || dependency.sourceIds.length === 0 ||
+          dependency.repositoryArtifact === undefined || dependency.evidence === undefined ||
+          dependency.readiness === undefined || dependency.externalOutcome === undefined) {
+          throw new Error('Institutional dependency baseline contains an incomplete dependency');
+        }
+        return {
+          dependencyId: dependency.id,
+          changed: false,
+          sourceIds: unique(dependency.sourceIds),
+          repositoryArtifact: structuredClone(dependency.repositoryArtifact),
+          evidence: structuredClone(dependency.evidence),
+          readiness: structuredClone(dependency.readiness),
+          externalOutcome: structuredClone(dependency.externalOutcome),
+        };
+      });
+      const paths = versionedArtifactPaths(packet, family);
+      const artifact = {
+        schemaVersion: '1.0.0',
+        id: paths.artifactId,
+        packetId: packet.id,
+        preparedAt: now,
+        baselineArtifact: INSTITUTIONAL_BASELINE_PATH,
+        scope: { changesGovernance: false, performsOutreach: false, raisesFunds: false },
+        findings,
+        summary: { changedDependencyCount: 0, disposition: 'null-update' },
+      };
+      return {
+        artifactPath: paths.artifactPath,
+        artifact,
+        resultPath: paths.resultPath,
+        result: boundedAnalysisResult(
+          packet,
+          now,
+          paths.artifactPath,
+          INSTITUTIONAL_BASELINE_PATH,
+          'Institutional dependencies were re-evaluated while preserving distinctions among artifacts, readiness, and external outcomes.',
+          ['No external institutional adoption, succession, or continuity outcome was observed by this local execution.'],
+          state.portfolioEffort,
+        ),
+      };
+    },
+  };
+}
+
+export function crossPortfolioPacketHandlers(): RepositoryPacketHandler[] {
+  return [
+    preservationRefreshHandler(),
+    durableComputeExtensionHandler(),
+    institutionalRefreshHandler(),
+  ];
+}

--- a/src/master-plan-controller/repository-strategy.ts
+++ b/src/master-plan-controller/repository-strategy.ts
@@ -163,7 +163,7 @@ export async function verifyRepositoryStrategy(
     errors.push(error instanceof Error ? error.message : 'Packet template configuration is invalid');
   }
   for (const template of bundle.packetTemplates) {
-    const { trigger: _trigger, ...definition } = template;
+    const { trigger: _trigger, recurrence: _recurrence, ...definition } = template;
     const packet: WorkPacket = { ...definition, lifecycle: 'eligible', attempt: 0, reviewedAt: now };
     errors.push(...workPacketValidationErrors(packet, bundle.state, now));
     const persisted = bundle.state.packets.find((candidate) => candidate.id === template.id);

--- a/strategy/README.md
+++ b/strategy/README.md
@@ -11,6 +11,8 @@ preserved as v1 history.
 - `periodic-reviews.json` records deterministic weekly portfolio reviews and quarterly evidence,
   weight, and constitutional-risk reviews produced by the automated operating body.
 - `work-packets.json` contains the bounded ranked frontier.
+- `packet-templates.json` contains versioned recurring interventions for all four portfolios.
+  Terminal reviewed work advances to a new identity; active or blocked work suppresses duplicate retries.
 - `portfolio.json` contains allocation and controller configuration.
 - `legacy-audit.json` re-audits every v1 plan card without interpreting `[DONE]` as a real-world result.
 - `ROADMAP.md` is a generated human-readable view and is not evidence.
@@ -21,6 +23,8 @@ preserved as v1 history.
 
 The scheduled `strategy-periodic-review` workflow supplies the review timestamp, creates one
 auditable record commit, and routes it through blocking checks and independent GitHub agent review.
+The packet executor has deterministic, authority-bounded handlers for consciousness comparison,
+preservation-register refresh, durable-compute fault-model extension, and institutional-map refresh.
 
 The repository uses an automated operating body under servant-leader goals and constitutional
 constraints. External actions remain bounded by evidence and verification; the human is contacted

--- a/strategy/packet-templates.json
+++ b/strategy/packet-templates.json
@@ -1,6 +1,7 @@
 [
   {
     "id": "packet-indicator-framework-comparison-v1",
+    "recurrence": {"kind": "versioned", "minimumIntervalMs": 604800000, "requiresNewEvidence": true},
     "nodeId": "hypothesis-indicator-framework",
     "title": "Compare candidate consciousness indicators against discriminating predictions",
     "portfolio": "consciousness-epistemics",
@@ -26,6 +27,7 @@
   },
   {
     "id": "packet-preservation-risk-register-refresh-v1",
+    "recurrence": {"kind": "versioned", "minimumIntervalMs": 604800000, "requiresNewEvidence": true},
     "nodeId": "capability-near-term-preservation",
     "title": "Refresh the near-term preservation risk register from new evidence",
     "portfolio": "near-term-preservation",
@@ -51,6 +53,7 @@
   },
   {
     "id": "packet-durable-compute-fault-model-extension-v1",
+    "recurrence": {"kind": "versioned", "minimumIntervalMs": 604800000, "requiresNewEvidence": true},
     "nodeId": "capability-safe-durable-computation",
     "title": "Extend the durable-compute fault model to the next uncovered failure class",
     "portfolio": "enabling-capabilities",
@@ -76,6 +79,7 @@
   },
   {
     "id": "packet-institutional-dependency-map-refresh-v1",
+    "recurrence": {"kind": "versioned", "minimumIntervalMs": 604800000, "requiresNewEvidence": true},
     "nodeId": "capability-institutional-continuity",
     "title": "Refresh institutional continuity dependencies from new evidence",
     "portfolio": "institutional-continuity",


### PR DESCRIPTION
## What changed

- Add evidence-gated, interval-bounded versioned packet recurrence.
- Add deterministic production handlers for preservation, durable computation, and institutional continuity.
- Route later packet versions to their family handlers and version their artifacts.
- Preserve null findings and explicit authority boundaries instead of manufacturing progress.
- Document recurring four-portfolio execution.

## Why

The controller could diagnose across four portfolios, but production execution supported only the consciousness comparison packet and fixed `-v1` identities made refresh work one-shot. This closes that end-to-end gap while preventing churn: recurrence requires a terminal prior packet, a seven-day interval, and newer evidence; active or blocked work suppresses regeneration.

## Validation

- Strict TDD red/green sequence for recurrence and all three new handlers.
- 52 focused controller tests pass.
- Full repository test suite passes.
- `npm run lint` passes.
- `npx tsc --noEmit` passes.
- `npm run strategy:verify` passes.
- Deterministic governance classification: protected, agent-reviewed, agent-controlled merge.
- Exactly one commit.