### PR TITLE
Serialize automated strategy writers

### DIFF
--- a/.github/workflows/strategy-cycle.yml
+++ b/.github/workflows/strategy-cycle.yml
@@ -12,12 +12,13 @@ permissions:
   pull-requests: write
 
 concurrency:
-  group: strategy-candidate-cycle
+  group: strategy-state-writer
   cancel-in-progress: false
 
 jobs:
   generate-candidates:
     runs-on: ubuntu-latest
+    timeout-minutes: 75
     steps:
       - uses: actions/checkout@v4
         with:
@@ -79,3 +80,4 @@ jobs:
           gh workflow run agent-review.yml --repo "$GITHUB_REPOSITORY" --ref main \
             -f pr_number="$pr_number" -f head_sha="$head_sha"
           gh pr merge "$pr_url" --auto --squash
+          npm run strategy:await-pr-merge -- "$pr_url" "$GITHUB_REPOSITORY" 360 10000

--- a/.github/workflows/strategy-execution.yml
+++ b/.github/workflows/strategy-execution.yml
@@ -12,12 +12,13 @@ permissions:
   pull-requests: write
 
 concurrency:
-  group: strategy-packet-execution
+  group: strategy-state-writer
   cancel-in-progress: false
 
 jobs:
   execute-packet:
     runs-on: ubuntu-latest
+    timeout-minutes: 75
     steps:
       - uses: actions/checkout@v4
         with:
@@ -85,3 +86,4 @@ jobs:
           gh workflow run agent-review.yml --repo "$GITHUB_REPOSITORY" --ref main \
             -f pr_number="$pr_number" -f head_sha="$head_sha"
           gh pr merge "$pr_url" --auto --squash
+          npm run strategy:await-pr-merge -- "$pr_url" "$GITHUB_REPOSITORY" 360 10000

--- a/.github/workflows/strategy-integrate-reviewed.yml
+++ b/.github/workflows/strategy-integrate-reviewed.yml
@@ -19,7 +19,7 @@ permissions:
   pull-requests: write
 
 concurrency:
-  group: strategy-reviewed-integration-${{ inputs.pr_number }}-${{ inputs.head_sha }}
+  group: strategy-state-writer
   cancel-in-progress: false
 
 jobs:
@@ -27,22 +27,29 @@ jobs:
     if: github.event_name == 'schedule'
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: main
       - name: Redispatch merged execution results for idempotent integration
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
           gh pr list --repo "$GITHUB_REPOSITORY" --state merged --limit 100 \
-            --json number,body,headRefOid \
-            --jq '.[] | select((.body // "") | contains("strategy-execution:packet:")) | [.number, .headRefOid] | @tsv' \
-            | while IFS=$'\t' read -r pr_number head_sha; do
+            --json number,body,headRefOid,mergedAt \
+            --jq 'sort_by(.mergedAt)[] | select((.body // "") | contains("strategy-execution:packet:")) | [.number, .headRefOid, ((.body | split("strategy-execution:packet:")[1]) | split(":result:")[0])] | @tsv' \
+            | while IFS=$'\t' read -r pr_number head_sha packet_id; do
+                lifecycle="$(jq -er --arg packet "$packet_id" '.[] | select(.id == $packet) | .lifecycle' strategy/work-packets.json)"
+                if test "$lifecycle" != verified; then
                 gh workflow run strategy-integrate-reviewed.yml --repo "$GITHUB_REPOSITORY" --ref main \
                   -f pr_number="$pr_number" -f head_sha="$head_sha"
+                  break
+                fi
               done
   integrate-reviewed-result:
     if: github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 75
     steps:
       - name: Bind the execution marker and exact agent review
         id: attestation
@@ -171,3 +178,4 @@ jobs:
           gh workflow run agent-review.yml --repo "$GITHUB_REPOSITORY" --ref main \
             -f pr_number="$pr_number" -f head_sha="$head_sha"
           gh pr merge "$pr_url" --auto --squash
+          npm run strategy:await-pr-merge -- "$pr_url" "$GITHUB_REPOSITORY" 360 10000

--- a/.github/workflows/strategy-periodic-review.yml
+++ b/.github/workflows/strategy-periodic-review.yml
@@ -18,12 +18,13 @@ permissions:
   pull-requests: write
 
 concurrency:
-  group: strategy-periodic-review
+  group: strategy-state-writer
   cancel-in-progress: false
 
 jobs:
   review:
     runs-on: ubuntu-latest
+    timeout-minutes: 75
     steps:
       - uses: actions/checkout@v4
         with:
@@ -87,3 +88,4 @@ jobs:
           gh workflow run agent-review.yml --repo "$GITHUB_REPOSITORY" --ref main \
             -f pr_number="$pr_number" -f head_sha="$head_sha"
           gh pr merge "$pr_url" --auto --squash
+          npm run strategy:await-pr-merge -- "$pr_url" "$GITHUB_REPOSITORY" 360 10000

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "strategy:generate": "tsx src/master-plan-controller/cli/generate-candidates-main.ts",
     "strategy:execute": "tsx src/master-plan-controller/cli/execute-packet-main.ts",
     "strategy:integrate-reviewed-execution": "tsx src/master-plan-controller/cli/integrate-reviewed-execution-main.ts",
+    "strategy:await-pr-merge": "tsx src/master-plan-controller/cli/await-pr-merge-main.ts",
     "strategy:integrate-result": "tsx src/master-plan-controller/cli/integrate-result-main.ts",
     "governance:classify": "tsx src/master-plan-controller/cli/classify-change.ts",
     "auto-merge:evaluate": "tsx src/master-plan-controller/cli/evaluate-auto-merge.ts",

--- a/src/master-plan-controller/__tests__/await-pr-merge.test.ts
+++ b/src/master-plan-controller/__tests__/await-pr-merge.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from 'vitest';
+import { waitForPullRequestMerge } from '../await-pr-merge.js';
+import type { ProcessPort, ProcessRequest, ProcessResult } from '../ports.js';
+import { InMemoryScheduler } from '../testing/in-memory-adapters.js';
+
+class SequencedProcess implements ProcessPort {
+  readonly requests: ProcessRequest[] = [];
+
+  constructor(private readonly results: ProcessResult[]) {}
+
+  async run(request: ProcessRequest): Promise<ProcessResult> {
+    this.requests.push(structuredClone(request));
+    const result = this.results.shift();
+    if (!result) throw new Error('Unexpected process invocation');
+    return result;
+  }
+}
+
+const result = (stdout: string, exitCode = 0): ProcessResult => ({ exitCode, stdout, stderr: '' });
+
+describe('reviewed pull-request merge wait', () => {
+  it('polls through the injected process and scheduler until the PR merges', async () => {
+    const process = new SequencedProcess([
+      result('{"state":"OPEN","mergedAt":null}'),
+      result('{"state":"MERGED","mergedAt":"2026-08-04T08:00:00Z"}'),
+    ]);
+    const scheduler = new InMemoryScheduler();
+
+    await expect(waitForPullRequestMerge(process, scheduler, {
+      pullRequest: 'https://github.com/rookdaemon/MASTER_PLAN/pull/142',
+      repository: 'rookdaemon/MASTER_PLAN',
+      maximumAttempts: 3,
+      delayMs: 10_000,
+    })).resolves.toEqual({ mergedAt: '2026-08-04T08:00:00Z', attempts: 2 });
+
+    expect(process.requests).toEqual([
+      {
+        command: 'gh',
+        args: ['pr', 'view', 'https://github.com/rookdaemon/MASTER_PLAN/pull/142', '--repo',
+          'rookdaemon/MASTER_PLAN', '--json', 'state,mergedAt'],
+      },
+      {
+        command: 'gh',
+        args: ['pr', 'view', 'https://github.com/rookdaemon/MASTER_PLAN/pull/142', '--repo',
+          'rookdaemon/MASTER_PLAN', '--json', 'state,mergedAt'],
+      },
+    ]);
+    expect(scheduler.waits).toEqual([10_000]);
+  });
+
+  it('fails closed on closed, malformed, failed, and timed-out observations', async () => {
+    const cases: Array<[ProcessResult[], RegExp]> = [
+      [[result('{"state":"CLOSED","mergedAt":null}')], /closed without merging/i],
+      [[result('not-json')], /malformed/i],
+      [[{ exitCode: 1, stdout: '', stderr: 'unavailable' }], /lookup failed.*unavailable/i],
+      [[result('{"state":"OPEN","mergedAt":null}'), result('{"state":"OPEN","mergedAt":null}')], /did not merge/i],
+    ];
+    for (const [results, expected] of cases) {
+      const scheduler = new InMemoryScheduler();
+      await expect(waitForPullRequestMerge(new SequencedProcess(results), scheduler, {
+        pullRequest: '142', repository: 'rookdaemon/MASTER_PLAN', maximumAttempts: 2, delayMs: 1,
+      })).rejects.toThrow(expected);
+    }
+  });
+});

--- a/src/master-plan-controller/__tests__/workflow-governance.test.ts
+++ b/src/master-plan-controller/__tests__/workflow-governance.test.ts
@@ -100,6 +100,12 @@ describe('blocking CI and governed workflows', () => {
     const executionCycle = await fileSystem.readText('.github/workflows/strategy-execution.yml');
     const reviewedIntegration = await fileSystem.readText('.github/workflows/strategy-integrate-reviewed.yml');
     const periodicReview = await fileSystem.readText('.github/workflows/strategy-periodic-review.yml');
+    for (const stateWriter of [strategyCycle, executionCycle, reviewedIntegration, periodicReview]) {
+      expect(stateWriter).toContain('group: strategy-state-writer');
+      expect(stateWriter).toContain('timeout-minutes: 75');
+      expect(stateWriter).toContain('npm run strategy:await-pr-merge');
+      expect(stateWriter.indexOf('gh pr merge')).toBeLessThan(stateWriter.indexOf('npm run strategy:await-pr-merge'));
+    }
     expect(proposal).toContain('pull_request:');
     expect(proposal).toContain('npm run governance:classify');
     expect(proposal).toContain('PR_COMMIT_COUNT');
@@ -237,6 +243,10 @@ describe('blocking CI and governed workflows', () => {
     expect(reviewedIntegration).toContain('workflow_dispatch:');
     expect(reviewedIntegration).toContain('schedule:');
     expect(reviewedIntegration).toContain('Redispatch merged execution results for idempotent integration');
+    expect(reviewedIntegration).toContain('sort_by(.mergedAt)');
+    expect(reviewedIntegration).toContain('strategy/work-packets.json');
+    expect(reviewedIntegration).toContain('if test "$lifecycle" != verified; then');
+    expect(reviewedIntegration).toMatch(/gh workflow run strategy-integrate-reviewed\.yml[\s\S]*break/);
     expect(reviewedIntegration).toContain('strategy-execution:packet:');
     expect(reviewedIntegration).toContain('Agent review PR #${PR_NUMBER} @ ${HEAD_SHA}');
     expect(reviewedIntegration).toContain('merge_commit_sha');
@@ -275,6 +285,7 @@ describe('blocking CI and governed workflows', () => {
       'strategy:generate': 'tsx src/master-plan-controller/cli/generate-candidates-main.ts',
       'strategy:execute': 'tsx src/master-plan-controller/cli/execute-packet-main.ts',
       'strategy:integrate-reviewed-execution': 'tsx src/master-plan-controller/cli/integrate-reviewed-execution-main.ts',
+      'strategy:await-pr-merge': 'tsx src/master-plan-controller/cli/await-pr-merge-main.ts',
     });
   });
 });

--- a/src/master-plan-controller/await-pr-merge.ts
+++ b/src/master-plan-controller/await-pr-merge.ts
@@ -1,0 +1,66 @@
+import type { ProcessPort, SchedulerPort } from './ports.js';
+import type { Timestamp } from './types.js';
+
+export interface PullRequestMergeWaitOptions {
+  pullRequest: string;
+  repository: string;
+  maximumAttempts: number;
+  delayMs: number;
+}
+
+export interface PullRequestMergeWaitResult {
+  mergedAt: Timestamp;
+  attempts: number;
+}
+
+interface PullRequestState {
+  state: 'OPEN' | 'CLOSED' | 'MERGED';
+  mergedAt: string | null;
+}
+
+function validOptions(options: PullRequestMergeWaitOptions): boolean {
+  return options.pullRequest.trim().length > 0 &&
+    /^[^/\s]+\/[^/\s]+$/.test(options.repository) &&
+    Number.isSafeInteger(options.maximumAttempts) && options.maximumAttempts > 0 &&
+    Number.isSafeInteger(options.delayMs) && options.delayMs >= 0;
+}
+
+function parseState(stdout: string): PullRequestState {
+  try {
+    const parsed = JSON.parse(stdout) as Partial<PullRequestState>;
+    if (!['OPEN', 'CLOSED', 'MERGED'].includes(parsed.state ?? '') ||
+      (parsed.mergedAt !== null && typeof parsed.mergedAt !== 'string')) {
+      throw new Error('invalid fields');
+    }
+    return parsed as PullRequestState;
+  } catch {
+    throw new Error('Pull request state response is malformed');
+  }
+}
+
+export async function waitForPullRequestMerge(
+  process: ProcessPort,
+  scheduler: SchedulerPort,
+  options: PullRequestMergeWaitOptions,
+): Promise<PullRequestMergeWaitResult> {
+  if (!validOptions(options)) throw new Error('Pull request merge wait options are invalid');
+  for (let attempt = 1; attempt <= options.maximumAttempts; attempt += 1) {
+    const observation = await process.run({
+      command: 'gh',
+      args: ['pr', 'view', options.pullRequest, '--repo', options.repository, '--json', 'state,mergedAt'],
+    });
+    if (observation.exitCode !== 0) {
+      throw new Error(`Pull request lookup failed: ${observation.stderr}`);
+    }
+    const state = parseState(observation.stdout);
+    if (state.state === 'MERGED') {
+      if (!state.mergedAt || Number.isNaN(Date.parse(state.mergedAt))) {
+        throw new Error('Pull request state response is malformed');
+      }
+      return { mergedAt: state.mergedAt, attempts: attempt };
+    }
+    if (state.state === 'CLOSED') throw new Error('Pull request closed without merging');
+    if (attempt < options.maximumAttempts) await scheduler.wait(options.delayMs);
+  }
+  throw new Error(`Pull request did not merge after ${options.maximumAttempts} observations`);
+}

--- a/src/master-plan-controller/cli/await-pr-merge-main.ts
+++ b/src/master-plan-controller/cli/await-pr-merge-main.ts
@@ -1,0 +1,22 @@
+import { waitForPullRequestMerge } from '../await-pr-merge.js';
+import { NodeProcess, NodeScheduler } from '../runtime-adapters.js';
+import { NodeCliRuntime } from './runtime.js';
+
+async function main(): Promise<void> {
+  const cli = new NodeCliRuntime();
+  try {
+    const [pullRequest, repository, attemptsInput, delayInput] = cli.arguments();
+    const result = await waitForPullRequestMerge(new NodeProcess(), new NodeScheduler(), {
+      pullRequest: pullRequest ?? '',
+      repository: repository ?? '',
+      maximumAttempts: Number(attemptsInput),
+      delayMs: Number(delayInput),
+    });
+    cli.write(JSON.stringify(result));
+  } catch (error) {
+    cli.writeError(error instanceof Error ? error.message : String(error));
+    cli.fail();
+  }
+}
+
+void main();

--- a/src/master-plan-controller/index.ts
+++ b/src/master-plan-controller/index.ts
@@ -1,5 +1,6 @@
 export * from './authority.js';
 export * from './auto-merge-service.js';
+export * from './await-pr-merge.js';
 export * from './change-classifier.js';
 export * from './continuous-loop.js';
 export * from './controller.js';

--- a/src/master-plan-controller/runtime-adapters.ts
+++ b/src/master-plan-controller/runtime-adapters.ts
@@ -12,6 +12,7 @@ import type {
   ProcessPort,
   ProcessRequest,
   ProcessResult,
+  SchedulerPort,
 } from './ports.js';
 import type { Timestamp } from './types.js';
 
@@ -88,6 +89,12 @@ export class FetchNetwork implements NetworkPort {
 export class NodeSha256Fingerprint implements ContentFingerprintPort {
   digest(content: string): string {
     return createHash('sha256').update(content, 'utf8').digest('hex');
+  }
+}
+
+export class NodeScheduler implements SchedulerPort {
+  async wait(milliseconds: number): Promise<void> {
+    await new Promise<void>((resolveWait) => setTimeout(resolveWait, milliseconds));
   }
 }
 


### PR DESCRIPTION
## What changed

- Give every strategy-state mutation workflow one shared repository-wide writer lock.
- Hold that lock until the exact reviewed PR is actually merged, with a bounded 60-minute fail-closed poll behind injected process and scheduler ports.
- Extend workflow timeouts to cover independent review and merge completion.
- Drain reviewed execution integrations oldest-first, one unintegrated result per hourly recovery pass, avoiding GitHub single-pending-run starvation.

## Why

The workflows previously used separate concurrency groups and released them immediately after arming auto-merge. Two writers could therefore branch from the same `main` and race, while mass redispatch could replace pending integrations.

## Validation

- Strict red/green tests for merge polling and writer workflow contracts.
- `npm run lint`
- `npm test -- --reporter=dot`
- `npm run strategy:verify`
- Prettier YAML validation for all changed workflows.