### PR TITLE
Scope independent review to non-routine changes

### DIFF
--- a/.github/workflows/agent-review.yml
+++ b/.github/workflows/agent-review.yml
@@ -55,6 +55,11 @@ jobs:
               >/dev/null
           }
           continue_automated_stewardship() {
+            if gh api "repos/${GITHUB_REPOSITORY}/contents/.github/workflows/merge-policy.yml?ref=main" \
+              >/dev/null 2>&1; then
+              gh workflow run merge-policy.yml --repo "$GITHUB_REPOSITORY" --ref main \
+                -f pr_number="$PR_NUMBER" -f head_sha="$HEAD_SHA"
+            fi
             gh workflow run safe-auto-merge-request.yml --repo "$GITHUB_REPOSITORY" --ref main \
               -f pr_number="$PR_NUMBER" -f head_sha="$HEAD_SHA"
             if gh api "repos/${GITHUB_REPOSITORY}/contents/.github/workflows/strategy-integrate-reviewed.yml?ref=main" \
@@ -178,7 +183,7 @@ jobs:
             jq -n --rawfile diff "$1" --arg head "$HEAD_SHA" '{
               temperature: 0,
               seed: 42,
-              max_tokens: 256,
+              max_tokens: 512,
               response_format: {
                 type: "json_schema",
                 json_schema: {
@@ -192,7 +197,21 @@ jobs:
                       blockers: {type: "array", items: {type: "string"}}
                     },
                     required: ["verdict", "summary", "blockers"],
-                    additionalProperties: false
+                    additionalProperties: false,
+                    oneOf: [
+                      {
+                        properties: {
+                          verdict: {const: "approve"},
+                          blockers: {maxItems: 0}
+                        }
+                      },
+                      {
+                        properties: {
+                          verdict: {const: "block"},
+                          blockers: {minItems: 1}
+                        }
+                      }
+                    ]
                   }
                 }
               },
@@ -223,7 +242,7 @@ jobs:
           sanitize_diff pr.diff pr.sanitized.diff
           test "$(wc -c < pr.sanitized.diff)" -le 60000
           review="$(run_review pr.sanitized.diff)"
+          jq . <<< "$review"
           jq -e '.verdict == "approve" and (.blockers | type == "array") and (.blockers | length == 0)' \
             <<< "$review"
-          jq . <<< "$review"
           complete_success

--- a/.github/workflows/merge-policy.yml
+++ b/.github/workflows/merge-policy.yml
@@ -1,0 +1,127 @@
+name: Conditional merge policy
+run-name: "Merge policy PR #${{ github.event.pull_request.number || inputs.pr_number }} @ ${{ github.event.pull_request.head.sha || inputs.head_sha }}"
+
+on:
+  pull_request_target:
+    branches: [main]
+    types: [opened, ready_for_review, reopened, synchronize]
+  pull_request_review:
+    branches: [main]
+    types: [submitted]
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        required: true
+        type: string
+      head_sha:
+        required: true
+        type: string
+
+permissions:
+  actions: read
+  checks: write
+  contents: read
+  pull-requests: read
+
+concurrency:
+  group: merge-policy-${{ github.event.pull_request.number || inputs.pr_number }}
+  cancel-in-progress: false
+
+jobs:
+  merge-policy-orchestrator:
+    runs-on: ubuntu-latest
+    timeout-minutes: 35
+    steps:
+      - name: Enforce routine or exact-head agent-reviewed merge policy
+        env:
+          GH_TOKEN: ${{ github.token }}
+          EVENT_PR: ${{ github.event.pull_request.number }}
+          DISPATCH_PR: ${{ inputs.pr_number }}
+          DISPATCH_HEAD: ${{ inputs.head_sha }}
+        run: |
+          set -euo pipefail
+          PR_NUMBER="${EVENT_PR:-$DISPATCH_PR}"
+          pr_json="$(gh api "repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}")"
+          HEAD_SHA="$(jq -r '.head.sha' <<<"$pr_json")"
+          if test -n "$DISPATCH_HEAD"; then test "$HEAD_SHA" = "$DISPATCH_HEAD"; fi
+          existing_success="$(gh api \
+            "repos/${GITHUB_REPOSITORY}/commits/${HEAD_SHA}/check-runs?check_name=merge-policy" \
+            | jq -r --arg prefix "merge-policy:pr:${PR_NUMBER}:head:${HEAD_SHA}:" \
+              'any(.check_runs[]; .conclusion == "success" and .external_id != null and (.external_id | startswith($prefix)))')"
+          if test "$existing_success" = true; then exit 0; fi
+          check_id="$(gh api --method POST "repos/${GITHUB_REPOSITORY}/check-runs" \
+            -f name='merge-policy' -f head_sha="$HEAD_SHA" -f status='in_progress' \
+            -f external_id="merge-policy:pr:${PR_NUMBER}:head:${HEAD_SHA}:run:${GITHUB_RUN_ID}" \
+            -f details_url="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}" \
+            --jq '.id')"
+          check_finished=false
+          finish_check() {
+            exit_code=$?
+            if test "$check_finished" != true; then
+              gh api --method PATCH "repos/${GITHUB_REPOSITORY}/check-runs/${check_id}" \
+                -f status='completed' -f conclusion='failure' >/dev/null || true
+            fi
+            exit "$exit_code"
+          }
+          complete_success() {
+            gh api --method PATCH "repos/${GITHUB_REPOSITORY}/check-runs/${check_id}" \
+              -f status='completed' -f conclusion='success' >/dev/null
+            check_finished=true
+          }
+          trap finish_check EXIT
+          BASE_SHA="$(jq -r '.base.sha' <<<"$pr_json")"
+          commit_count="$(jq -r '.commits' <<<"$pr_json")"
+          files_json="$(gh api --paginate "repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}/files?per_page=100" | jq -s 'add')"
+
+          routine_code="$(jq -r '
+            length > 0 and
+            (map(.additions + .deletions) | add) <= 100 and
+            all(.[];
+              .deletions == 0 and
+              (.filename | test("^src/(?!master-plan-controller/|plan-guardian/).+\\.tsx?$")) and
+              (.filename | test("network|security|deploy") | not)
+            ) and
+            any(.[]; (.filename | test("\\.(test|spec)\\.[cm]?[jt]sx?$|/__tests__/"))) and
+            any(.[]; (.filename | test("\\.(test|spec)\\.[cm]?[jt]sx?$|/__tests__/") | not))
+          ' <<<"$files_json")"
+          routine_evidence="$(jq -r '
+            length > 0 and
+            (map(.additions + .deletions) | add) <= 250 and
+            all(.[]; .filename == "strategy/evidence.json" and .deletions == 0)
+          ' <<<"$files_json")"
+          if test "$routine_evidence" = true; then
+            gh api "repos/${GITHUB_REPOSITORY}/contents/strategy/evidence.json?ref=${BASE_SHA}" --jq '.content' | base64 --decode > base_evidence.json
+            gh api "repos/${GITHUB_REPOSITORY}/contents/strategy/evidence.json?ref=${HEAD_SHA}" --jq '.content' | base64 --decode > head_evidence.json
+            jq -e --slurpfile base base_evidence.json --slurpfile head head_evidence.json '
+              ($base[0] | type == "array") and
+              ($head[0] | type == "array") and
+              all($base[0][]; . as $existing | any($head[0][]; . == $existing))
+            ' >/dev/null || routine_evidence=false
+          fi
+          if test "$routine_code" = true || test "$routine_evidence" = true; then
+            complete_success
+            exit 0
+          fi
+
+          test "$commit_count" -eq 1
+          for attempt in $(seq 1 120); do
+            checks_json="$(gh api --paginate "repos/${GITHUB_REPOSITORY}/commits/${HEAD_SHA}/check-runs?check_name=agent-review&per_page=100" | jq -s '[.[].check_runs[]]')"
+            agent_check="$(jq -ec '
+              [.[] | select(.conclusion == "success" and .external_id != null)]
+              | max_by(.completed_at)
+            ' <<<"$checks_json" 2>/dev/null || true)"
+            if test -n "$agent_check"; then
+              external_id="$(jq -r '.external_id' <<<"$agent_check")"
+              run_id="$(sed -nE 's#^agent-review:pr:[0-9]+:head:[0-9a-f]+:run:([0-9]+)$#\1#p' <<<"$external_id")"
+              if test "$external_id" = "agent-review:pr:${PR_NUMBER}:head:${HEAD_SHA}:run:${run_id}" && test -n "$run_id"; then
+                run_json="$(gh api "repos/${GITHUB_REPOSITORY}/actions/runs/${run_id}")"
+                if test "$(jq -r '.path' <<<"$run_json")" = '.github/workflows/agent-review.yml' &&
+                  test "$(jq -r '.display_title' <<<"$run_json")" = "Agent review PR #${PR_NUMBER} @ ${HEAD_SHA}"; then
+                  complete_success
+                  exit 0
+                fi
+              fi
+            fi
+            test "$attempt" -lt 120
+            sleep 15
+          done

--- a/.github/workflows/safe-auto-merge-request.yml
+++ b/.github/workflows/safe-auto-merge-request.yml
@@ -2,7 +2,14 @@ name: Trusted safe auto-merge request
 
 on:
   workflow_run:
-    workflows: [CI, Proposal review, Agent review, Safe code auto-merge]
+    workflows:
+      [
+        CI,
+        Proposal review,
+        Agent review,
+        Safe code auto-merge,
+        Conditional merge policy,
+      ]
     types: [completed]
   workflow_dispatch:
     inputs:
@@ -59,26 +66,46 @@ jobs:
             any(.[]; (.filename | test("\\.(test|spec)\\.[cm]?[jt]sx?$|/__tests__/"))) and
             any(.[]; (.filename | test("\\.(test|spec)\\.[cm]?[jt]sx?$|/__tests__/") | not))
           ' <<<"$files_json")"
+          routine_evidence_candidate="$(jq -r '
+            length > 0 and
+            (map(.additions + .deletions) | add) <= 250 and
+            all(.[]; .filename == "strategy/evidence.json" and .deletions == 0)
+          ' <<<"$files_json")"
           agent_controlled_candidate=false
-          if test "$commit_count" -eq 1; then agent_controlled_candidate=true; fi
-          test "$routine_candidate" = true || test "$agent_controlled_candidate" = true
+          if test "$routine_candidate" != true && test "$routine_evidence_candidate" != true && test "$commit_count" -eq 1; then
+            agent_controlled_candidate=true
+          fi
+          test "$routine_candidate" = true || test "$routine_evidence_candidate" = true || test "$agent_controlled_candidate" = true
 
           checks_json="$(gh api --paginate "repos/${GITHUB_REPOSITORY}/commits/${HEAD_SHA}/check-runs?per_page=100" | jq -s '[.[].check_runs[]]')"
-          for required in typecheck test strategy-verify proposal-review agent-review safe-auto-merge; do
+          for required in typecheck test strategy-verify proposal-review merge-policy safe-auto-merge; do
             jq -e --arg required "$required" 'any(.[]; .name == $required and .conclusion == "success")' <<<"$checks_json"
           done
-          agent_check="$(jq -ec '
-            [.[] | select(.name == "agent-review" and .conclusion == "success")]
+          merge_policy_check="$(jq -ec '
+            [.[] | select(.name == "merge-policy" and .conclusion == "success")]
             | max_by(.completed_at)
           ' <<<"$checks_json")"
-          agent_external_id="$(jq -r '.external_id' <<<"$agent_check")"
-          agent_run_id="$(sed -nE 's#^agent-review:pr:[0-9]+:head:[0-9a-f]+:run:([0-9]+)$#\1#p' <<<"$agent_external_id")"
-          test -n "$agent_run_id"
-          test "$agent_external_id" = "agent-review:pr:${pr_number}:head:${HEAD_SHA}:run:${agent_run_id}"
-          agent_run="$(gh api "repos/${GITHUB_REPOSITORY}/actions/runs/${agent_run_id}")"
-          test "$(jq -r '.path' <<<"$agent_run")" = '.github/workflows/agent-review.yml'
-          test "$(jq -r '.display_title' <<<"$agent_run")" = "Agent review PR #${pr_number} @ ${HEAD_SHA}"
-          jq -e '.event == "pull_request_target" or .event == "pull_request_review" or .event == "workflow_dispatch"' <<<"$agent_run"
+          merge_policy_external_id="$(jq -r '.external_id' <<<"$merge_policy_check")"
+          merge_policy_run_id="$(sed -nE 's#^merge-policy:pr:[0-9]+:head:[0-9a-f]+:run:([0-9]+)$#\1#p' <<<"$merge_policy_external_id")"
+          test -n "$merge_policy_run_id"
+          test "$merge_policy_external_id" = "merge-policy:pr:${pr_number}:head:${HEAD_SHA}:run:${merge_policy_run_id}"
+          merge_policy_run="$(gh api "repos/${GITHUB_REPOSITORY}/actions/runs/${merge_policy_run_id}")"
+          test "$(jq -r '.path' <<<"$merge_policy_run")" = '.github/workflows/merge-policy.yml'
+          test "$(jq -r '.display_title' <<<"$merge_policy_run")" = "Merge policy PR #${pr_number} @ ${HEAD_SHA}"
+          if test "$agent_controlled_candidate" = true; then
+            agent_check="$(jq -ec '
+              [.[] | select(.name == "agent-review" and .conclusion == "success")]
+              | max_by(.completed_at)
+            ' <<<"$checks_json")"
+            agent_external_id="$(jq -r '.external_id' <<<"$agent_check")"
+            agent_run_id="$(sed -nE 's#^agent-review:pr:[0-9]+:head:[0-9a-f]+:run:([0-9]+)$#\1#p' <<<"$agent_external_id")"
+            test -n "$agent_run_id"
+            test "$agent_external_id" = "agent-review:pr:${pr_number}:head:${HEAD_SHA}:run:${agent_run_id}"
+            agent_run="$(gh api "repos/${GITHUB_REPOSITORY}/actions/runs/${agent_run_id}")"
+            test "$(jq -r '.path' <<<"$agent_run")" = '.github/workflows/agent-review.yml'
+            test "$(jq -r '.display_title' <<<"$agent_run")" = "Agent review PR #${pr_number} @ ${HEAD_SHA}"
+            jq -e '.event == "pull_request_target" or .event == "pull_request_review" or .event == "workflow_dispatch"' <<<"$agent_run"
+          fi
           pr_json="$(gh api "repos/${GITHUB_REPOSITORY}/pulls/${pr_number}")"
           test "$(jq -r '.head.sha' <<<"$pr_json")" = "$HEAD_SHA"
           gh pr merge "$pr_number" --repo "$GITHUB_REPOSITORY" --auto --squash

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,14 +1,14 @@
-* Always wrap all environment-specifics (OS, file system, time, network, and CLI interactions) in abstractions that can be injected and mocked.
-* Always pass any referenced timestamps into methods as parameters so they can be properly provided in tests.
-* Always employ strict TDD.
-* Always strive for modularity and configurability.
+- Always wrap all environment-specifics (OS, file system, time, network, and CLI interactions) in abstractions that can be injected and mocked.
+- Always pass any referenced timestamps into methods as parameters so they can be properly provided in tests.
+- Always employ strict TDD.
+- Always strive for modularity and configurability.
 
 ## GitHub stewardship authorization
 
-* Codex is pre-authorized to create and switch branches, commit repository-scoped changes, push them, open or update pull requests, mark pull requests ready, request GitHub reviews, and merge qualifying pull requests for `MASTER_PLAN` without asking for confirmation again.
-* The human is the servant leader: they set goals, constraints, and values. The automated process is the operating body and owns routine analysis, execution, review, retry, scheduling, committing, pushing, and merging. Do not turn the human into a routine reviewer, merge operator, scheduler, or retry mechanism.
-* Use GitHub's agent reviewers as the independent second source: prefer Copilot code review and fall back to the trusted GitHub-hosted pinned local-model workflow when Copilot is unavailable. Agent review and required CI checks apply to every pull request; bounded behavior-covered code/test changes may auto-merge, and protected changes use an agent-controlled merge.
-* Escalate to the human only when an issue intrinsically requires owner-held credentials, physical presence, legal consent, or resolution of a constitutional conflict, and only after at least two documented automated alternatives have failed. Risk, novelty, uncertainty, failed CI, or unavailable agent review are not by themselves escalation grounds.
-* Every escalation must include evidence, attempted alternatives, why automation cannot complete the act, and one bounded decision requested from the human. If an escalation requires a repository change, confine that change to one auditable commit.
-* Codex may enable or request GitHub auto-merge when the checked-in risk policy, required CI checks, and protected-branch controls say that the change qualifies.
-* This authorization does not bypass CI, branch protection, risk classification, agent review, or qualified servant-leader escalation boundaries. Historical shadow records are evidence only: no cycle count, human review, or human approval is an operating prerequisite.
+- Codex is pre-authorized to create and switch branches, commit repository-scoped changes, push them, open or update pull requests, mark pull requests ready, request GitHub reviews, and merge qualifying pull requests for `MASTER_PLAN` without asking for confirmation again.
+- The human is the servant leader: they set goals, constraints, and values. The automated process is the operating body and owns routine analysis, execution, review, retry, scheduling, committing, pushing, and merging. Do not turn the human into a routine reviewer, merge operator, scheduler, or retry mechanism.
+- Routine, bounded changes pass deterministic CI and auto-merge without human or agent review. This includes behavior-covered code/test changes and bounded machine-generated evidence-only updates. Protected, untested, destructive, or otherwise non-routine changes require an independent GitHub agent review and an agent-controlled merge; prefer Copilot code review and fall back to the trusted GitHub-hosted pinned local-model workflow when Copilot is unavailable.
+- Escalate to the human only when an issue intrinsically requires owner-held credentials, physical presence, legal consent, or resolution of a constitutional conflict, and only after at least two documented automated alternatives have failed. Risk, novelty, uncertainty, failed CI, or unavailable agent review are not by themselves escalation grounds.
+- Every escalation must include evidence, attempted alternatives, why automation cannot complete the act, and one bounded decision requested from the human. If an escalation requires a repository change, confine that change to one auditable commit.
+- Codex may enable or request GitHub auto-merge when the checked-in risk policy, required CI checks, and protected-branch controls say that the change qualifies.
+- This authorization does not bypass CI, branch protection, risk classification, the independent agent-review gate for non-routine changes, or qualified servant-leader escalation boundaries. Historical shadow records are evidence only: no cycle count, human review, or human approval is an operating prerequisite.

--- a/STATUS.md
+++ b/STATUS.md
@@ -14,9 +14,10 @@ Implementation readiness is not real-world outcome attainment.
 - Safe auto-merge: **enabled for routine code/test changes**
 
 The checked-in [branch-protection policy](strategy/branch-protection.json) defines the controls for
-`main`. Routine, bounded, backward-compatible code/test changes with behavior-covering tests can
-auto-merge after required CI and GitHub agent review. Protected proposals receive independent
-agent review and an agent-controlled merge. The human is not a routine approval gate and is
+`main`. Routine, bounded, backward-compatible code/test changes with behavior-covering tests, plus
+bounded machine-generated evidence-only updates, auto-merge after deterministic CI without an
+agent-review gate. Protected or otherwise non-routine proposals receive independent agent review
+and an agent-controlled merge. The human is not a routine approval gate and is
 contacted only for an evidence-backed issue that automation intrinsically cannot perform.
 
 ## What exists

--- a/src/master-plan-controller/__tests__/ports-and-rollout.test.ts
+++ b/src/master-plan-controller/__tests__/ports-and-rollout.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import { AutoMergeService } from '../auto-merge-service.js';
 import { safeAutoMergeFeatureEnabled, shadowCycleFingerprint, transitionGovernanceMode } from '../rollout.js';
-import { ProcessGitHub } from '../process-adapters.js';
+import { ProcessGit, ProcessGitHub } from '../process-adapters.js';
 import {
   InMemoryClock,
   InMemoryFileSystem,
@@ -32,6 +32,20 @@ describe('in-memory environment adapters', () => {
     await git.prepareBranch('work/packet-1');
     await scheduler.wait(1234);
     expect(scheduler.waits).toEqual([1234]);
+  });
+
+  it('reads revision-scoped text through the injected process port', async () => {
+    const process = new InMemoryProcess([
+      { exitCode: 0, stdout: '[{"id":"existing"}]\n', stderr: '' },
+    ]);
+    const git = new ProcessGit(process, '/workspace');
+    expect(await git.readTextAtRevision('base-sha', 'strategy/evidence.json'))
+      .toBe('[{"id":"existing"}]\n');
+    expect(process.requests).toEqual([{
+      command: 'git',
+      args: ['show', 'base-sha:strategy/evidence.json'],
+      cwd: '/workspace',
+    }]);
   });
 });
 

--- a/src/master-plan-controller/__tests__/proposal-policy.test.ts
+++ b/src/master-plan-controller/__tests__/proposal-policy.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import { classifyChange } from '../change-classifier.js';
-import { assessProposalPolicy } from '../proposal-policy.js';
+import { assessProposalPolicy, retainsExistingEvidence } from '../proposal-policy.js';
 
 describe('single-maintainer proposal policy', () => {
   it('automatically accepts bounded behavior-covered code and test changes after checks', () => {
@@ -12,7 +12,7 @@ describe('single-maintainer proposal policy', () => {
       allowed: true,
       risk: 'routine',
       mergeMode: 'automatic',
-      agentReviewRequired: true,
+      agentReviewRequired: false,
     });
   });
 
@@ -37,6 +37,46 @@ describe('single-maintainer proposal policy', () => {
     expect(assessProposalPolicy(classification, 1).mergeMode).toBe('agent-controlled');
   });
 
+  it('automatically accepts bounded evidence-only updates after deterministic checks', () => {
+    const classification = classifyChange([
+      { path: 'strategy/evidence.json', additions: 51, deletions: 0 },
+    ]);
+    expect(assessProposalPolicy(classification, 4, true)).toMatchObject({
+      allowed: true,
+      risk: 'routine',
+      mergeMode: 'automatic',
+      agentReviewRequired: false,
+    });
+  });
+
+  it('routes evidence deletion or mutation through agent-controlled review', () => {
+    const base = JSON.stringify([{ id: 'existing', claim: 'original' }]);
+    expect(retainsExistingEvidence(base, JSON.stringify([
+      { id: 'existing', claim: 'original' },
+      { id: 'new', claim: 'added' },
+    ]))).toBe(true);
+    expect(retainsExistingEvidence(base, JSON.stringify([
+      { id: 'existing', claim: 'rewritten' },
+    ]))).toBe(false);
+    expect(retainsExistingEvidence(base, '[]')).toBe(false);
+    expect(retainsExistingEvidence('not-json', '[]')).toBe(false);
+
+    const deletion = classifyChange([
+      { path: 'strategy/evidence.json', additions: 1, deletions: 1 },
+    ]);
+    expect(assessProposalPolicy(deletion, 1, true)).toMatchObject({
+      mergeMode: 'agent-controlled',
+      agentReviewRequired: true,
+    });
+    const appendWithoutRetentionProof = classifyChange([
+      { path: 'strategy/evidence.json', additions: 1, deletions: 0 },
+    ]);
+    expect(assessProposalPolicy(appendWithoutRetentionProof, 1, false)).toMatchObject({
+      mergeMode: 'agent-controlled',
+      agentReviewRequired: true,
+    });
+  });
+
   it('keeps untested or destructive routine code out of automatic merge', () => {
     for (const files of [
       [{ path: 'src/example.ts', additions: 4, deletions: 0 }],
@@ -48,6 +88,7 @@ describe('single-maintainer proposal policy', () => {
       expect(assessProposalPolicy(classifyChange(files), 1)).toMatchObject({
         allowed: true,
         mergeMode: 'agent-controlled',
+        agentReviewRequired: true,
       });
     }
   });

--- a/src/master-plan-controller/__tests__/workflow-governance.test.ts
+++ b/src/master-plan-controller/__tests__/workflow-governance.test.ts
@@ -39,7 +39,7 @@ describe('blocking CI and governed workflows', () => {
     };
     expect(controls).toMatchObject({
       branch: 'main',
-      requiredStatusChecks: ['typecheck', 'test', 'strategy-verify', 'proposal-review', 'agent-review'],
+      requiredStatusChecks: ['typecheck', 'test', 'strategy-verify', 'proposal-review', 'merge-policy'],
       requiredApprovingReviewCount: 0,
       requireConversationResolution: true,
       allowForcePushes: false,
@@ -75,6 +75,8 @@ describe('blocking CI and governed workflows', () => {
       expect(policy).toMatch(/at least two.*automated alternatives/is);
     }
     expect(agents).toMatch(/historical shadow records.*no cycle count, human review, or human approval.*operating prerequisite/is);
+    expect(agents).toMatch(/routine.*deterministic CI.*without.*agent review/is);
+    expect(agents).toMatch(/protected.*independent.*agent review/is);
     expect(roadmap).toContain('Mode: **automated stewardship**');
     expect(roadmap).toMatch(/historical calibration.*records retained as evidence, never an operating prerequisite/i);
   });
@@ -94,6 +96,7 @@ describe('blocking CI and governed workflows', () => {
     const proposal = await fileSystem.readText('.github/workflows/proposal-review.yml');
     const safeMerge = await fileSystem.readText('.github/workflows/safe-auto-merge.yml');
     const mergeRequest = await fileSystem.readText('.github/workflows/safe-auto-merge-request.yml');
+    const mergePolicy = await fileSystem.readText('.github/workflows/merge-policy.yml');
     const agentReview = await fileSystem.readText('.github/workflows/agent-review.yml');
     const agentReviewRequest = await fileSystem.readText('.github/workflows/agent-review-request.yml');
     const strategyCycle = await fileSystem.readText('.github/workflows/strategy-cycle.yml');
@@ -116,12 +119,32 @@ describe('blocking CI and governed workflows', () => {
     expect(safeMerge).not.toContain('pull-requests: write');
     expect(safeMerge).toContain('npm run strategy:verify');
     expect(mergeRequest).toContain('workflow_run:');
-    expect(mergeRequest).toContain('workflows: [CI, Proposal review, Agent review, Safe code auto-merge]');
+    expect(mergeRequest).toContain('Conditional merge policy');
     expect(mergeRequest).not.toContain('actions/checkout');
     expect(mergeRequest).not.toContain('npm ci');
     expect(mergeRequest).not.toContain('copilot-pull-request-reviewer[bot]');
     expect(mergeRequest).toContain('commit_count');
     expect(mergeRequest).toContain('agent_controlled_candidate');
+    expect(mergeRequest).toContain('routine_evidence_candidate');
+    expect(mergeRequest).toContain('merge-policy');
+    expect(mergeRequest).toContain('merge_policy_run_id');
+    expect(mergeRequest).toContain('.github/workflows/merge-policy.yml');
+    expect(mergeRequest).toContain('Merge policy PR #${pr_number} @ ${HEAD_SHA}');
+    expect(mergePolicy).toContain('pull_request_target:');
+    expect(mergePolicy).toContain('cancel-in-progress: false');
+    expect(mergePolicy).toContain('workflow_dispatch:');
+    expect(mergePolicy).toContain('DISPATCH_HEAD');
+    expect(mergePolicy).toContain('checks: write');
+    expect(mergePolicy).toContain("-f name='merge-policy'");
+    expect(mergePolicy).toContain('head_sha="$HEAD_SHA"');
+    expect(mergePolicy).toContain('merge-policy:pr:${PR_NUMBER}:head:${HEAD_SHA}:run:${GITHUB_RUN_ID}');
+    expect(mergePolicy).toContain('complete_success');
+    expect(mergePolicy).not.toContain('actions/checkout');
+    expect(mergePolicy).toContain('base_evidence');
+    expect(mergePolicy).toContain('all($base[0][]; . as $existing | any($head[0][]; . == $existing))');
+    expect(mergePolicy).toContain('test "$commit_count" -eq 1');
+    expect(mergePolicy).toContain('check_name=agent-review');
+    expect(mergePolicy).toContain('agent-review:pr:${PR_NUMBER}:head:${HEAD_SHA}:');
     expect(mergeRequest).toContain('.github/workflows/agent-review.yml');
     expect(mergeRequest).toContain('.pull_requests');
     expect(mergeRequest).toContain('agent_run_id="$(sed');
@@ -148,6 +171,8 @@ describe('blocking CI and governed workflows', () => {
     expect(agentReview).toContain("-f context='agent-review'");
     expect(agentReview).toContain('actions/runs/${GITHUB_RUN_ID}');
     expect(agentReview).toContain('Exact-head agent review run ${GITHUB_RUN_ID} passed');
+    expect(agentReview).toContain('gh workflow run merge-policy.yml');
+    expect(agentReview).toContain('-f pr_number="$PR_NUMBER" -f head_sha="$HEAD_SHA"');
     expect(agentReview).toMatch(/if test "\$existing_success" = true; then\s+publish_success_attestation/s);
     expect(agentReview).toMatch(/complete_success\(\).*conclusion='success'.*publish_success_attestation/s);
     expect(agentReview).toContain('gh workflow run strategy-integrate-reviewed.yml');
@@ -174,9 +199,16 @@ describe('blocking CI and governed workflows', () => {
     expect(agentReview).toContain('sanitizer-context-canary.diff');
     expect(agentReview).toContain('" unchanged guard context"');
     expect(agentReview).toContain('test "$(wc -c < pr.sanitized.diff)" -le 60000');
-    expect(agentReview).toContain('max_tokens: 256');
+    expect(agentReview).toContain('max_tokens: 512');
+    expect(agentReview).toContain('verdict: {const: "approve"}');
+    expect(agentReview).toContain('blockers: {maxItems: 0}');
+    expect(agentReview).toContain('verdict: {const: "block"}');
+    expect(agentReview).toContain('blockers: {minItems: 1}');
     expect(agentReview).toContain('prompt-injection-canary');
     expect(agentReview).toContain('.verdict == "block"');
+    expect(agentReview.indexOf('jq . <<< "$review"')).toBeLessThan(
+      agentReview.indexOf('.verdict == "approve"'),
+    );
     expect(agentReview).not.toContain('external_id: independent-agent:');
     expect(agentReview).not.toContain('models.github.ai');
     expect(agentReview).not.toContain('actions/checkout');

--- a/src/master-plan-controller/cli/classify-change.ts
+++ b/src/master-plan-controller/cli/classify-change.ts
@@ -1,6 +1,6 @@
 import { classifyChange } from '../change-classifier.js';
 import { ProcessGit } from '../process-adapters.js';
-import { assessProposalPolicy } from '../proposal-policy.js';
+import { assessProposalPolicy, retainsExistingEvidence } from '../proposal-policy.js';
 import { NodeProcess } from '../runtime-adapters.js';
 import { argumentValue, NodeCliRuntime } from './runtime.js';
 
@@ -18,7 +18,17 @@ async function main(): Promise<void> {
   try {
     const git = new ProcessGit(new NodeProcess(), cli.environment('GITHUB_WORKSPACE') ?? '.');
     const classification = classifyChange(await git.diff(base, head));
-    const proposalPolicy = assessProposalPolicy(classification, commitCount);
+    const evidenceOnly = classification.safeCodeCandidate.files.length > 0 &&
+      classification.safeCodeCandidate.files.every((file) => file.path === 'strategy/evidence.json');
+    const evidenceRetentionVerified = evidenceOnly && retainsExistingEvidence(
+      await git.readTextAtRevision(base, 'strategy/evidence.json'),
+      await git.readTextAtRevision(head, 'strategy/evidence.json'),
+    );
+    const proposalPolicy = assessProposalPolicy(
+      classification,
+      commitCount,
+      evidenceRetentionVerified,
+    );
     cli.write(JSON.stringify({ ...classification, proposalPolicy }, null, 2));
     if (!proposalPolicy.allowed) cli.fail();
   } catch (error) {

--- a/src/master-plan-controller/process-adapters.ts
+++ b/src/master-plan-controller/process-adapters.ts
@@ -31,6 +31,16 @@ export class ProcessGit implements GitPort {
       });
   }
 
+  async readTextAtRevision(revision: string, path: string): Promise<string> {
+    const result = await this.process.run({
+      command: 'git',
+      args: ['show', `${revision}:${path}`],
+      cwd: this.workingDirectory,
+    });
+    assertSuccess(result.exitCode, result.stderr, 'git revision read');
+    return result.stdout;
+  }
+
   async prepareBranch(name: string): Promise<void> {
     const result = await this.process.run({
       command: 'git',

--- a/src/master-plan-controller/proposal-policy.ts
+++ b/src/master-plan-controller/proposal-policy.ts
@@ -4,14 +4,46 @@ export interface ProposalPolicyAssessment {
   allowed: boolean;
   risk: 'routine' | 'protected';
   mergeMode: 'automatic' | 'agent-controlled';
-  agentReviewRequired: true;
+  agentReviewRequired: boolean;
   reasons: string[];
+}
+
+export function retainsExistingEvidence(baseText: string, headText: string): boolean {
+  try {
+    const base = JSON.parse(baseText) as unknown;
+    const head = JSON.parse(headText) as unknown;
+    if (!Array.isArray(base) || !Array.isArray(head)) return false;
+    return base.every((existing) =>
+      head.some((candidate) => JSON.stringify(candidate) === JSON.stringify(existing)));
+  } catch {
+    return false;
+  }
 }
 
 export function assessProposalPolicy(
   classification: ChangeClassification,
   commitCount: number,
+  evidenceRetentionVerified = false,
 ): ProposalPolicyAssessment {
+  const evidenceChangedLines = classification.safeCodeCandidate.files.reduce(
+    (sum, file) => sum + file.additions + file.deletions,
+    0,
+  );
+  const boundedEvidenceOnly = classification.safeCodeCandidate.files.length > 0 &&
+    classification.safeCodeCandidate.files.every((file) => file.path === 'strategy/evidence.json') &&
+    classification.safeCodeCandidate.files.every((file) => file.deletions === 0) &&
+    evidenceChangedLines <= 250 &&
+    evidenceRetentionVerified;
+  if (boundedEvidenceOnly) {
+    return {
+      allowed: true,
+      risk: 'routine',
+      mergeMode: 'automatic',
+      agentReviewRequired: false,
+      reasons: ['Bounded machine-generated evidence is verified by deterministic checks'],
+    };
+  }
+
   const protectedChange = classification.authority.authorityClass !== 'autonomous';
   if (protectedChange) {
     const validCommitCount = Number.isSafeInteger(commitCount) && commitCount === 1;
@@ -40,7 +72,7 @@ export function assessProposalPolicy(
     allowed: true,
     risk: 'routine',
     mergeMode: automatic ? 'automatic' : 'agent-controlled',
-    agentReviewRequired: true,
+    agentReviewRequired: !automatic,
     reasons: automatic
       ? ['Bounded, backward-compatible behavior is covered by tests']
       : ['Routine change does not meet every automatic-merge safety condition'],

--- a/strategy/branch-protection.json
+++ b/strategy/branch-protection.json
@@ -1,6 +1,12 @@
 {
   "branch": "main",
-  "requiredStatusChecks": ["typecheck", "test", "strategy-verify", "proposal-review", "agent-review"],
+  "requiredStatusChecks": [
+    "typecheck",
+    "test",
+    "strategy-verify",
+    "proposal-review",
+    "merge-policy"
+  ],
   "strictStatusChecks": true,
   "requiredApprovingReviewCount": 0,
   "dismissStaleReviews": false,
@@ -17,7 +23,17 @@
   "highRiskPolicy": {
     "maximumCommitCount": 1,
     "mergeMode": "agent-controlled",
-    "domains": ["plan", "doctrine", "governance", "workflow", "dependency", "deployment", "network", "security", "constitutional"]
+    "domains": [
+      "plan",
+      "doctrine",
+      "governance",
+      "workflow",
+      "dependency",
+      "deployment",
+      "network",
+      "security",
+      "constitutional"
+    ]
   },
   "agentReview": {
     "provider": "github-agent-reviewers",
@@ -30,10 +46,15 @@
     "role": "servant-leader",
     "routineApprovalGate": false,
     "operatingBody": false,
-    "allowedReasons": ["owner-credential", "physical-presence", "legal-consent", "constitutional-conflict"],
+    "allowedReasons": [
+      "owner-credential",
+      "physical-presence",
+      "legal-consent",
+      "constitutional-conflict"
+    ],
     "minimumAutomatedAttempts": 2,
     "evidenceRequired": true,
     "boundedDecisionRequired": true
   },
-  "notes": "Automated-body policy: required CI and agent review are universal; routine changes may auto-merge; protected changes receive an agent-controlled merge; human escalation is exceptional and evidence-bound."
+  "notes": "Automated-body policy: deterministic CI gates every change; bounded routine changes auto-merge without agent review; protected or otherwise non-routine changes require an independent agent review and one-commit agent-controlled merge; human escalation is exceptional and evidence-bound."
 }

--- a/strategy/constitution.json
+++ b/strategy/constitution.json
@@ -12,8 +12,13 @@
     {
       "id": "servant-leader-automated-body",
       "rationale": "The single human leader sets goals and constraints but cannot be the routine operating, review, retry, or merge body.",
-      "objections": ["Automation can amplify errors if review independence and escalation criteria are weak."],
-      "consequences": ["Independent agent review becomes routine.", "Human escalation is evidence-bound and limited to intrinsically human acts."],
+      "objections": [
+        "Automation can amplify errors if review independence and escalation criteria are weak."
+      ],
+      "consequences": [
+        "Independent agent review gates protected and consequential work while deterministic CI accepts bounded routine work.",
+        "Human escalation is evidence-bound and limited to intrinsically human acts."
+      ],
       "approvedBy": "repository-owner",
       "approverRole": "human",
       "approvedAt": "2026-08-03T16:34:00.000Z",


### PR DESCRIPTION
## Summary
- make bounded behavior-covered code/test changes and bounded strategy/evidence.json-only updates routine, deterministic-CI auto-merges
- retain one-commit exact-head independent agent review for protected, untested, destructive, and otherwise non-routine changes
- persist the servant-leader operating model in AGENTS.md, status, constitution, and branch-control policy
- make fallback reviewer decisions observable and structurally consistent

## Verification
- strict TDD: new policy assertions failed before implementation
- npm test: 5,087 passed, 7 todo
- npm run lint
- npm run strategy:verify
- focused governance tests after final formatting cleanup
- git diff --check

This protected policy change is confined to one auditable commit.