### PR TITLE
Stabilize proactive cycle test fixtures

### DIFF
--- a/src/master-plan-controller/__tests__/repository-candidate-generation.test.ts
+++ b/src/master-plan-controller/__tests__/repository-candidate-generation.test.ts
@@ -12,15 +12,21 @@ async function repositorySnapshot(): Promise<Record<string, string>> {
     ...(await source.listFiles('plan/')),
   ];
   const snapshot = Object.fromEntries(await Promise.all(paths.map(async (path) => [path, await source.readText(path)])));
+  // Reconstruct the state immediately before the two candidates under test. The repository snapshot
+  // may already contain them after a successful live cycle; unrelated historical work stays intact.
+  const generatedPacketIds = new Set([
+    'packet-indicator-framework-comparison-v1',
+    'packet-preservation-mitigation-tabletop-v1',
+  ]);
   snapshot['strategy/work-packets.json'] = `${JSON.stringify(
     (JSON.parse(snapshot['strategy/work-packets.json']) as Array<{ id: string }>).filter((packet) =>
-      packet.id !== 'packet-indicator-framework-comparison-v1'),
+      !generatedPacketIds.has(packet.id)),
     null,
     2,
   )}\n`;
   snapshot['strategy/audit-log.json'] = `${JSON.stringify(
     (JSON.parse(snapshot['strategy/audit-log.json']) as Array<{ packetId?: string }>).filter((event) =>
-      event.packetId !== 'packet-indicator-framework-comparison-v1'),
+      !event.packetId || !generatedPacketIds.has(event.packetId)),
     null,
     2,
   )}\n`;

--- a/src/master-plan-controller/__tests__/repository-packet-execution.test.ts
+++ b/src/master-plan-controller/__tests__/repository-packet-execution.test.ts
@@ -41,10 +41,14 @@ async function executableRepository(): Promise<{ fileSystem: InMemoryFileSystem;
     'strategy/results/consciousness-prediction-registry-v1.json':
       await source.readText('strategy/results/consciousness-prediction-registry-v1.json'),
   };
-  const packets = JSON.parse(initial['strategy/work-packets.json']) as Array<{ id: string; lifecycle: string }>;
-  const executable = packets.find((packet) => packet.id === 'packet-indicator-framework-comparison-v1');
+  const sourcePackets = JSON.parse(initial['strategy/work-packets.json']) as Array<{ id: string; lifecycle: string }>;
+  const executable = sourcePackets.find((packet) => packet.id === 'packet-indicator-framework-comparison-v1');
   if (!executable) throw new Error('Indicator comparison packet fixture is missing');
-  executable.lifecycle = 'eligible';
+  // Copy repository data into a controlled in-memory lifecycle fixture.
+  const packets = sourcePackets.map((packet) => ({
+    ...packet,
+    lifecycle: packet.id === executable.id ? 'eligible' : 'verified',
+  }));
   initial['strategy/work-packets.json'] = `${JSON.stringify(packets, null, 2)}\n`;
   return { fileSystem: new InMemoryFileSystem(initial), now: nextRepositoryTimestamp(initial) };
 }
@@ -75,8 +79,11 @@ async function repositoryWithEligibleTemplate(packetId: string, runtimePacketId 
   definition.retrySignature = String(definition.retrySignature).replace(/-v1$/, `-v${version}`);
   definition.deliverables = (definition.deliverables as string[])
     .map((deliverable) => deliverable.replace(/-v1$/, `-v${version}`));
-  const packets = JSON.parse(initial['strategy/work-packets.json']) as Array<Record<string, unknown>>;
-  for (const packet of packets) packet.lifecycle = 'verified';
+  // Replace a live instance of this template, if present, with the controlled eligible fixture below.
+  const packets: Array<Record<string, unknown>> =
+    (JSON.parse(initial['strategy/work-packets.json']) as Array<Record<string, unknown>>)
+    .filter((packet) => packet.id !== runtimePacketId)
+    .map((packet) => ({ ...packet, lifecycle: 'verified' }));
   packets.push({ ...definition, lifecycle: 'eligible', attempt: 0, reviewedAt: now });
   initial['strategy/work-packets.json'] = `${JSON.stringify(packets, null, 2)}\n`;
   return { fileSystem: new InMemoryFileSystem(initial), now };


### PR DESCRIPTION
Fixes the live-cycle regression exposed by run 30937069904. Repository-backed tests now normalize mutable packet lifecycle state and remove pre-existing instances of the packets under generation, so an automated strategy proposal can validate itself after adding a packet.\n\nVerification: npm run lint; npm run strategy:verify; npm test.