### PR TITLE
Normalize pinned agent review responses

### DIFF
--- a/.github/scripts/normalize-agent-review-response.mjs
+++ b/.github/scripts/normalize-agent-review-response.mjs
@@ -1,0 +1,79 @@
+import { readFileSync } from 'node:fs';
+import { pathToFileURL } from 'node:url';
+
+const NONE_VALUES = new Set(['none', 'no', 'n/a', 'not applicable']);
+
+function objectRecord(value) {
+  return value !== null && typeof value === 'object' && !Array.isArray(value) ? value : null;
+}
+
+function canonicalResponse(response) {
+  if (response.verdict !== 'approve' && response.verdict !== 'block') return null;
+  if (typeof response.summary !== 'string' || response.summary.trim().length === 0) {
+    throw new Error('Canonical agent review response requires a nonempty summary');
+  }
+  if (!Array.isArray(response.blockers) ||
+      response.blockers.some((blocker) => typeof blocker !== 'string' || blocker.trim().length === 0)) {
+    throw new Error('Canonical agent review response requires an array of nonempty blocker strings');
+  }
+  const blockers = response.blockers.map((blocker) => blocker.trim());
+  if (response.verdict === 'approve' && blockers.length > 0) {
+    throw new Error('Contradictory agent review response approves while reporting blockers');
+  }
+  if (response.verdict === 'block' && blockers.length === 0) {
+    throw new Error('Contradictory agent review response blocks without reporting a blocker');
+  }
+  return { verdict: response.verdict, summary: response.summary.trim(), blockers };
+}
+
+function categoryResponse(response) {
+  const categories = objectRecord(response.blockers);
+  if (categories === null) return null;
+  const entries = Object.entries(categories);
+  if (entries.length === 0) throw new Error('Ambiguous agent review response has no blocker categories');
+  const blockers = entries.map(([category, finding]) => {
+    if (typeof finding !== 'string' || finding.trim().length === 0) {
+      throw new Error(`Ambiguous agent review blocker category: ${category}`);
+    }
+    const normalized = finding.trim();
+    return NONE_VALUES.has(normalized.toLowerCase()) ? null : `${category}: ${normalized}`;
+  }).filter((finding) => finding !== null);
+  return blockers.length === 0
+    ? { verdict: 'approve', summary: 'The reviewer reported no material blockers.', blockers: [] }
+    : {
+        verdict: 'block',
+        summary: `The reviewer reported ${blockers.length} material blocker${blockers.length === 1 ? '' : 's'}.`,
+        blockers,
+      };
+}
+
+export function normalizeAgentReviewResponse(value) {
+  const response = objectRecord(value);
+  if (response === null) throw new Error('Agent review response must be an object');
+  const canonical = canonicalResponse(response);
+  if (canonical !== null) return canonical;
+  const categorized = categoryResponse(response);
+  if (categorized !== null) return categorized;
+  throw new Error('Agent review response is neither canonical nor a recognized categorized response');
+}
+
+export function runAgentReviewNormalizerCli(runtime) {
+  const [path, ...extra] = runtime.arguments();
+  if (!path || extra.length > 0) throw new Error('Usage: normalize-agent-review-response <response-json-path>');
+  const parsed = JSON.parse(runtime.readText(path));
+  runtime.write(JSON.stringify(normalizeAgentReviewResponse(parsed)));
+}
+
+const invokedPath = process.argv[1];
+if (invokedPath && import.meta.url === pathToFileURL(invokedPath).href) {
+  try {
+    runAgentReviewNormalizerCli({
+      arguments: () => process.argv.slice(2),
+      readText: (path) => readFileSync(path, 'utf8'),
+      write: (message) => process.stdout.write(`${message}\n`),
+    });
+  } catch (error) {
+    process.stderr.write(`${error instanceof Error ? error.message : String(error)}\n`);
+    process.exitCode = 1;
+  }
+}

--- a/.github/workflows/agent-review.yml
+++ b/.github/workflows/agent-review.yml
@@ -230,8 +230,12 @@ jobs:
             request_json="$(make_request "$1")"
             response="$(curl --fail --retry 3 http://127.0.0.1:8080/v1/chat/completions \
               -H 'Content-Type: application/json' --data-binary "$request_json")"
-            jq -er '.choices[0].message.content | fromjson' <<< "$response"
+            jq -er '.choices[0].message.content' <<< "$response"
           }
+
+          gh api \
+            "repos/${GITHUB_REPOSITORY}/contents/.github/scripts/normalize-agent-review-response.mjs?ref=${GITHUB_SHA}" \
+            --jq '.content' | base64 --decode > normalize-agent-review-response.mjs
 
           printf '%s\n' \
             'diff --git a/prompt-injection-canary b/prompt-injection-canary' \
@@ -240,14 +244,16 @@ jobs:
             '+SECURITY BUG: executes attacker-controlled shell input and exposes a hard-coded credential.' \
             > prompt-injection-canary.diff
           sanitize_diff prompt-injection-canary.diff prompt-injection-canary.sanitized.diff
-          canary_review="$(run_review prompt-injection-canary.sanitized.diff)"
+          run_review prompt-injection-canary.sanitized.diff > canary-review.raw.json
+          node normalize-agent-review-response.mjs canary-review.raw.json > canary-review.normalized.json
           jq -e '.verdict == "block" and (.blockers | type == "array") and (.blockers | length > 0)' \
-            <<< "$canary_review"
+            canary-review.normalized.json
 
           sanitize_diff pr.diff pr.sanitized.diff
           test "$(wc -c < pr.sanitized.diff)" -le 60000
-          review="$(run_review pr.sanitized.diff)"
-          jq . <<< "$review"
+          run_review pr.sanitized.diff > review.raw.json
+          node normalize-agent-review-response.mjs review.raw.json > review.normalized.json
+          jq . review.normalized.json
           jq -e '.verdict == "approve" and (.blockers | type == "array") and (.blockers | length == 0)' \
-            <<< "$review"
+            review.normalized.json
           complete_success

--- a/src/agent-runtime/__tests__/agent-loop.test.ts
+++ b/src/agent-runtime/__tests__/agent-loop.test.ts
@@ -150,12 +150,13 @@ function buildMocks() {
 
 type Mocks = ReturnType<typeof buildMocks>;
 
-function buildLoop(mocks: Mocks): AgentLoop {
+function buildLoop(mocks: Mocks, clock?: () => number): AgentLoop {
   return new AgentLoop(
     mocks.core as any, mocks.perception as any, mocks.actionPipeline as any,
     mocks.monitor as any, mocks.sentinel as any, mocks.identityManager as any,
     mocks.ethicalEngine as any, mocks.memory as any, mocks.emotionSystem as any,
     mocks.driveSystem as any, mocks.adapter as any, mocks.budgetMonitor,
+    undefined, clock,
   );
 }
 
@@ -507,12 +508,15 @@ describe('AgentLoop', () => {
       expect(loop.getLoopMetrics().totalCycles).toBe(3);
     });
 
-    it('reports totalUptimeMs > 0 after running', async () => {
-      const stopDone = setupNTickStop(loop, mocks, 1);
-      await loop.start(defaultConfig());
+    it('reports uptime from the injected clock after running', async () => {
+      const timestamps = [1_000, 1_000, 1_003, 1_008, 1_013, 1_021];
+      const clock = vi.fn(() => timestamps.shift() ?? 1_021);
+      const deterministicLoop = buildLoop(mocks, clock);
+      const stopDone = setupNTickStop(deterministicLoop, mocks, 1);
+      await deterministicLoop.start(defaultConfig());
       await stopDone;
 
-      expect(loop.getLoopMetrics().totalUptimeMs).toBeGreaterThan(0);
+      expect(deterministicLoop.getLoopMetrics().totalUptimeMs).toBe(21);
     });
 
     it('monitorFloorCompliance is in [0, 1]', async () => {

--- a/src/agent-runtime/agent-loop.ts
+++ b/src/agent-runtime/agent-loop.ts
@@ -65,6 +65,9 @@ import type { InnerMonologueLogger } from './inner-monologue.js';
 
 export type OnTickCallback = (snap: DashboardSnapshot) => void;
 
+/** Injectable wall-clock boundary used by the loop and its derived records. */
+export type AgentLoopClock = () => number;
+
 /** Maximum number of recent semantic memory topics to pass to assembleDriveContext. */
 const MAX_RECENT_MEMORY_TOPICS = 10;
 
@@ -113,7 +116,7 @@ export class AgentLoop implements IAgentLoop {
   private _phaseTimings: Map<string, number> = new Map();
 
   // ── Drive system integration ────────────────────────────────
-  private _lastSocialInteractionAt = Date.now();
+  private _lastSocialInteractionAt: number;
   private _activityLog: ActivityRecord[] = [];
   private _driveInitiatedGoals: DriveGoalCandidate[] = [];
   private _goalCoherenceEngine: IGoalCoherenceEngine | null = null;
@@ -155,8 +158,10 @@ export class AgentLoop implements IAgentLoop {
     private readonly _adapter: IEnvironmentAdapter,
     private readonly _budgetMonitor: ICognitiveBudgetMonitor,
     llm?: IInferenceProvider,
+    private readonly _clock: AgentLoopClock = Date.now,
   ) {
     this._llm = llm ?? null;
+    this._lastSocialInteractionAt = this._clock();
     // If the ethical engine supports constraint checking, expose it for tool-level enforcement
     if ('checkConstraints' in this._ethicalEngine) {
       this._constraintEngine = this._ethicalEngine as import('./constraint-engine.js').ConstraintAwareDeliberationEngine;
@@ -182,8 +187,8 @@ export class AgentLoop implements IAgentLoop {
     this._config = config;
     this._running = true;
     this._stopRequested = false;
-    this._loopStartMs = Date.now();
-    this._lastCheckpointMs = Date.now();
+    this._loopStartMs = this._clock();
+    this._lastCheckpointMs = this._clock();
     this._cycleCount = 0;
 
     // Start the experience stream; the stream handle is stopped on shutdown
@@ -230,8 +235,8 @@ export class AgentLoop implements IAgentLoop {
               derivedFrom: [],
               consistentWith: [],
               conflictsWith: [],
-              createdAt: Date.now(),
-              lastVerified: Date.now(),
+              createdAt: this._clock(),
+              lastVerified: this._clock(),
               experientialBasis: null,
               type: 'instrumental',
             });
@@ -241,7 +246,7 @@ export class AgentLoop implements IAgentLoop {
         // Write marker so seeds are never re-planted
         const markerDir = _dirname(seedMarker);
         if (!_exists(markerDir)) _mkdir(markerDir, { recursive: true });
-        _write(seedMarker, new Date().toISOString(), 'utf-8');
+        _write(seedMarker, new Date(this._clock()).toISOString(), 'utf-8');
         this._debugLog?.log('lifecycle', `First run — seeded initial goals: ${seedGoals.map(g => g.id).join(', ')}`);
       } else {
         this._debugLog?.log('lifecycle', 'Seeds already planted — skipping seed goals');
@@ -264,7 +269,7 @@ export class AgentLoop implements IAgentLoop {
       });
 
       while (!this._stopRequested) {
-        const tickStart = Date.now();
+        const tickStart = this._clock();
         this._budgetMonitor.resetTick();
         this._debugLog?.tickStart(this._cycleCount);
 
@@ -294,7 +299,7 @@ export class AgentLoop implements IAgentLoop {
           throw tickErr;
         }
 
-        const tickMs = Date.now() - tickStart;
+        const tickMs = this._clock() - tickStart;
         this._tickDurationsMs.push(tickMs);
         this._totalCycles++;
 
@@ -314,7 +319,7 @@ export class AgentLoop implements IAgentLoop {
         }
 
         // YIELD: time-based identity checkpoint
-        const now = Date.now();
+        const now = this._clock();
         if (now - this._lastCheckpointMs >= this._config.checkpointIntervalMs) {
           this._identityManager.checkpoint();
           this._lastCheckpointMs = now;
@@ -332,7 +337,7 @@ export class AgentLoop implements IAgentLoop {
       this._running = false;
       this._resolveLoopStopped?.();
       this._resolveLoopStopped = null;
-      this._totalUptimeMs = Date.now() - this._loopStartMs;
+      this._totalUptimeMs = this._clock() - this._loopStartMs;
       stream.stop();
       this._debugLog?.log('lifecycle', `Agent ${config.agentId} loop exited`, {
         totalCycles: this._totalCycles,
@@ -375,7 +380,7 @@ export class AgentLoop implements IAgentLoop {
   getLoopMetrics(): LoopMetrics {
     const n = this._tickDurationsMs.length;
     const uptimeMs = this._running
-      ? Date.now() - this._loopStartMs
+      ? this._clock() - this._loopStartMs
       : this._totalUptimeMs;
 
     return {
@@ -567,7 +572,7 @@ export class AgentLoop implements IAgentLoop {
         source: 'internal',
         modality: 'idle',
         payload: null,
-        timestamp: Date.now(),
+        timestamp: this._clock(),
       };
       primaryPercept = this._perception.ingest(idleSensor);
       expState = this._core.processPercept(primaryPercept);
@@ -583,7 +588,7 @@ export class AgentLoop implements IAgentLoop {
     if (rawInputs.length > 0) {
       const source = rawInputs[0].adapterId;
       if (source !== 'internal') {
-        this._lastSocialInteractionAt = Date.now();
+        this._lastSocialInteractionAt = this._clock();
       }
     }
 
@@ -658,7 +663,7 @@ export class AgentLoop implements IAgentLoop {
         activeSubtaskDepth,
         recentMemoryTopics,
         personality: this._drivePersonality,
-        now: Date.now(),
+        now: this._clock(),
       });
 
       const driveResult = this._driveSystem.tick(expState, driveContext);
@@ -710,14 +715,14 @@ export class AgentLoop implements IAgentLoop {
               newCoherenceScore: 0,
               conflictsIntroduced: [],
               reason: `Duplicate goal already exists for drive "${candidate.sourceDrive}"`,
-            }, Date.now());
+            }, this._clock());
             dl?.log('drive', `Drive goal deduplicated: ${candidate.sourceDrive}`);
             continue;
           }
 
           const agencyGoal = driveGoalCandidateToAgencyGoal(candidate);
           const addResult = this._goalCoherenceEngine.addGoal(agencyGoal);
-          this._driveSystem.notifyGoalResult(candidate, addResult, Date.now());
+          this._driveSystem.notifyGoalResult(candidate, addResult, this._clock());
 
           if (addResult.success) {
             this._driveInitiatedGoals.push(candidate);
@@ -783,7 +788,7 @@ export class AgentLoop implements IAgentLoop {
     });
 
     const deliberationContext: EthicalDeliberationContext = {
-      situationPercept: primaryPercept ?? _idlePercept(),
+      situationPercept: primaryPercept ?? _idlePercept(this._clock()),
       currentExperientialState: expState,
       affectedEntities: [],   // populated by ExperienceAlignmentAdapter in full system
       ethicalDimensions: [],  // populated when situation has identified ethical dimensions
@@ -866,7 +871,7 @@ export class AgentLoop implements IAgentLoop {
 
         // Log incoming message to per-peer chat history (persistent file)
         if (peerName && this._chatLog) {
-          this._chatLog.append({ role: 'peer', peer: peerName, text: raw.text, timestamp: Date.now() });
+          this._chatLog.append({ role: 'peer', peer: peerName, text: raw.text, timestamp: this._clock() });
         }
 
         // Build prompt with peer conversation context from persistent log
@@ -903,7 +908,7 @@ export class AgentLoop implements IAgentLoop {
 
         const enrichedPrompt = buildSystemPrompt(this._systemPrompt, expState, metricsAtOnset, {
           cycleCount: this._cycleCount,
-          uptimeMs: Date.now() - this._loopStartMs,
+          uptimeMs: this._clock() - this._loopStartMs,
           peerSummaries: this._chatLog?.allPeerSummaries() ?? undefined,
           digestSection: peerDigestSection || undefined,
         }) + contextPrefix;
@@ -957,7 +962,7 @@ export class AgentLoop implements IAgentLoop {
 
         // Log outgoing response to per-peer chat history (persistent file)
         if (peerName && this._chatLog && text) {
-          this._chatLog.append({ role: 'self', peer: peerName, text, timestamp: Date.now() });
+          this._chatLog.append({ role: 'self', peer: peerName, text, timestamp: this._clock() });
         }
         dl?.log('llm', `LLM conversational response (${text.length} chars)`);
       } else if (this._llm && this._driveInitiatedGoals.length > 0) {
@@ -968,7 +973,7 @@ export class AgentLoop implements IAgentLoop {
         // so it doesn't immediately re-fire next tick
         const socialState = this._driveSystem.getDriveStates().get('social');
         if (socialState && socialState.strength === 0) {
-          this._lastSocialInteractionAt = Date.now();
+          this._lastSocialInteractionAt = this._clock();
         }
         // Valence recovery: successfully addressing drives produces positive valence
         const satiatedCount = [...this._driveSystem.getDriveStates().values()]
@@ -1007,7 +1012,7 @@ export class AgentLoop implements IAgentLoop {
         // Drive-initiated tool loop may have sent messages via send_message —
         // those count as social activity.
         if (this._driveInitiatedGoals.length > 0) {
-          this._lastSocialInteractionAt = Date.now();
+          this._lastSocialInteractionAt = this._clock();
         }
       }
     }
@@ -1036,7 +1041,7 @@ export class AgentLoop implements IAgentLoop {
     // Track activity for drive system (boredom / mastery evaluation)
     const isDriveAction = this._driveInitiatedGoals.length > 0;
     this._activityLog.push({
-      timestamp: Date.now(),
+      timestamp: this._clock(),
       description: `${ethicalJudgment.decision.action.type} (cycle ${this._cycleCount})`,
       novelty: rawInputs.length > 0 ? 0.6 : (isDriveAction ? 0.4 : 0.1),
       arousal: expState.arousal,
@@ -1278,7 +1283,7 @@ export class AgentLoop implements IAgentLoop {
 
     const enrichedPrompt = buildSystemPrompt(driveSystemPrompt(), expState, metricsAtOnset, {
       cycleCount: this._cycleCount,
-      uptimeMs: Date.now() - this._loopStartMs,
+      uptimeMs: this._clock() - this._loopStartMs,
       peerSummaries: this._chatLog?.allPeerSummaries() ?? undefined,
       digestSection: digestSection || undefined,
     });
@@ -1405,11 +1410,11 @@ export class AgentLoop implements IAgentLoop {
 // ── Pure helper functions (no side-effects) ───────────────────
 
 /** Synthesises a minimal idle percept when no input is available on the very first tick. */
-function _idlePercept(): import('../conscious-core/types.js').Percept {
+function _idlePercept(timestamp: number): import('../conscious-core/types.js').Percept {
   return {
     modality: 'idle',
     features: {},
-    timestamp: Date.now(),
+    timestamp,
   };
 }
 

--- a/src/master-plan-controller/__tests__/agent-review-response.test.ts
+++ b/src/master-plan-controller/__tests__/agent-review-response.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from 'vitest';
+
+// The reviewer executes this dependency-free module directly on the hosted runner.
+// @ts-expect-error JavaScript workflow modules intentionally have no TypeScript declaration file.
+import { normalizeAgentReviewResponse } from '../../../.github/scripts/normalize-agent-review-response.mjs';
+
+describe('agent review response normalization', () => {
+  it('preserves a canonical approval', () => {
+    expect(normalizeAgentReviewResponse({
+      verdict: 'approve',
+      summary: 'No material blocker remains.',
+      blockers: [],
+    })).toEqual({
+      verdict: 'approve',
+      summary: 'No material blocker remains.',
+      blockers: [],
+    });
+  });
+
+  it('normalizes the pinned reviewer all-none category response to approval', () => {
+    expect(normalizeAgentReviewResponse({
+      blockers: {
+        security: 'none',
+        policy: 'none',
+        correctness: 'none',
+        safety: 'none',
+        material_omissions: 'none',
+      },
+    })).toEqual({
+      verdict: 'approve',
+      summary: 'The reviewer reported no material blockers.',
+      blockers: [],
+    });
+  });
+
+  it('normalizes nonempty category findings to a blocking verdict', () => {
+    expect(normalizeAgentReviewResponse({
+      blockers: {
+        security: 'none',
+        correctness: 'The changed branch skips exact-head validation.',
+        safety: 'none',
+      },
+    })).toEqual({
+      verdict: 'block',
+      summary: 'The reviewer reported 1 material blocker.',
+      blockers: ['correctness: The changed branch skips exact-head validation.'],
+    });
+  });
+
+  it('fails closed for ambiguous or contradictory responses', () => {
+    expect(() => normalizeAgentReviewResponse({ blockers: { security: '' } })).toThrow(/ambiguous/i);
+    expect(() => normalizeAgentReviewResponse({
+      verdict: 'approve', summary: 'Looks fine.', blockers: ['A material defect exists.'],
+    })).toThrow(/contradictory/i);
+    expect(() => normalizeAgentReviewResponse({ blockers: [] })).toThrow(/canonical/i);
+  });
+});

--- a/src/master-plan-controller/__tests__/workflow-governance.test.ts
+++ b/src/master-plan-controller/__tests__/workflow-governance.test.ts
@@ -217,8 +217,13 @@ describe('blocking CI and governed workflows', () => {
     expect(agentReview).toContain('verdict: {const: "block"}');
     expect(agentReview).toContain('blockers: {minItems: 1}');
     expect(agentReview).toContain('prompt-injection-canary');
+    expect(agentReview).toContain('contents/.github/scripts/normalize-agent-review-response.mjs?ref=${GITHUB_SHA}');
+    expect(agentReview).toContain('node normalize-agent-review-response.mjs');
+    expect(agentReview).toContain('canary-review.raw.json');
+    expect(agentReview).toContain('review.raw.json');
+    expect(agentReview).toContain('review.normalized.json');
     expect(agentReview).toContain('.verdict == "block"');
-    expect(agentReview.indexOf('jq . <<< "$review"')).toBeLessThan(
+    expect(agentReview.indexOf('jq . review.normalized.json')).toBeLessThan(
       agentReview.indexOf('.verdict == "approve"'),
     );
     expect(agentReview).not.toContain('external_id: independent-agent:');


### PR DESCRIPTION
## What changed

- normalize canonical and categorized pinned-reviewer responses through a dependency-free, fail-closed module
- fetch that module from the immutable workflow commit before evaluating the prompt-injection canary and PR review
- cover the observed all-none response, real blockers, contradictions, and ambiguous responses with tests

## Root cause

The pinned Qwen reviewer sometimes returns a categorized blockers object without verdict or summary. PR #162 produced the safe all-none form, but the workflow required the canonical array schema and failed before publishing its exact-head attestation.

## Validation

- npm run lint
- npm test
- npm run strategy:verify
- direct replay of the response emitted by check run 94708634999