### PR TITLE
Make candidate cycle tests version invariant

### DIFF
--- a/src/master-plan-controller/__tests__/repository-candidate-generation.test.ts
+++ b/src/master-plan-controller/__tests__/repository-candidate-generation.test.ts
@@ -4,6 +4,7 @@ import { runCandidateGenerationCli } from '../cli/generate-candidates.js';
 import { NodeFileSystem } from '../runtime-adapters.js';
 import { InMemoryFileSystem } from '../testing/in-memory-adapters.js';
 import { advanceTimestamp, nextRepositoryTimestamp } from './repository-test-time.js';
+import { isVersionedPacketFamilyMember } from './repository-test-state.js';
 
 async function repositorySnapshot(): Promise<Record<string, string>> {
   const source = new NodeFileSystem('.');
@@ -14,19 +15,15 @@ async function repositorySnapshot(): Promise<Record<string, string>> {
   const snapshot = Object.fromEntries(await Promise.all(paths.map(async (path) => [path, await source.readText(path)])));
   // Reconstruct the state immediately before the two candidates under test. The repository snapshot
   // may already contain them after a successful live cycle; unrelated historical work stays intact.
-  const generatedPacketIds = new Set([
-    'packet-indicator-framework-comparison-v1',
-    'packet-preservation-mitigation-tabletop-v1',
-  ]);
   snapshot['strategy/work-packets.json'] = `${JSON.stringify(
     (JSON.parse(snapshot['strategy/work-packets.json']) as Array<{ id: string }>).filter((packet) =>
-      !generatedPacketIds.has(packet.id)),
+      !isVersionedPacketFamilyMember(packet.id)),
     null,
     2,
   )}\n`;
   snapshot['strategy/audit-log.json'] = `${JSON.stringify(
     (JSON.parse(snapshot['strategy/audit-log.json']) as Array<{ packetId?: string }>).filter((event) =>
-      !event.packetId || !generatedPacketIds.has(event.packetId)),
+      !event.packetId || !isVersionedPacketFamilyMember(event.packetId)),
     null,
     2,
   )}\n`;

--- a/src/master-plan-controller/__tests__/repository-test-state.test.ts
+++ b/src/master-plan-controller/__tests__/repository-test-state.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from 'vitest';
+import { isVersionedPacketFamilyMember } from './repository-test-state.js';
+
+describe('repository test state isolation', () => {
+  it('recognizes every generated version in a packet family', () => {
+    const families = [
+      'packet-indicator-framework-comparison',
+      'packet-preservation-mitigation-tabletop',
+    ];
+
+    expect(isVersionedPacketFamilyMember('packet-indicator-framework-comparison-v1', families)).toBe(true);
+    expect(isVersionedPacketFamilyMember('packet-indicator-framework-comparison-v2', families)).toBe(true);
+    expect(isVersionedPacketFamilyMember('packet-preservation-mitigation-tabletop-v23', families)).toBe(true);
+    expect(isVersionedPacketFamilyMember('packet-unrelated-v2', families)).toBe(false);
+    expect(isVersionedPacketFamilyMember('packet-indicator-framework-comparison-draft', families)).toBe(false);
+  });
+});

--- a/src/master-plan-controller/__tests__/repository-test-state.ts
+++ b/src/master-plan-controller/__tests__/repository-test-state.ts
@@ -1,0 +1,12 @@
+export const GENERATED_CANDIDATE_FAMILIES = [
+  'packet-indicator-framework-comparison',
+  'packet-preservation-mitigation-tabletop',
+] as const;
+
+export function isVersionedPacketFamilyMember(
+  packetId: string,
+  families: readonly string[] = GENERATED_CANDIDATE_FAMILIES,
+): boolean {
+  const match = /^(.*)-v[1-9]\d*$/.exec(packetId);
+  return match !== null && families.includes(match[1]!);
+}

--- a/src/master-plan-controller/__tests__/strategy-artifacts.test.ts
+++ b/src/master-plan-controller/__tests__/strategy-artifacts.test.ts
@@ -16,10 +16,10 @@ import {
   InMemoryScheduler,
 } from '../testing/in-memory-adapters.js';
 import { CONFIG, makeEscalation, makeEscalationEvidence, NOW } from './fixtures.js';
+import { isVersionedPacketFamilyMember } from './repository-test-state.js';
 
 const STRATEGY_NOW = '2026-08-04T00:30:00.000Z';
 const GENERATED_PACKET_ID = 'packet-indicator-framework-comparison-v1';
-const GENERATED_PRESERVATION_PACKET_ID = 'packet-preservation-mitigation-tabletop-v1';
 
 function repositoryNow(value: unknown): string {
   const epochs: number[] = [];
@@ -43,11 +43,10 @@ function withoutGeneratedCandidates<T extends { state: {
   activePacketId: string | null;
 } }>(bundle: T): T {
   const result = structuredClone(bundle);
-  const generatedPacketIds = new Set([GENERATED_PACKET_ID, GENERATED_PRESERVATION_PACKET_ID]);
-  result.state.packets = result.state.packets.filter((packet) => !generatedPacketIds.has(packet.id));
+  result.state.packets = result.state.packets.filter((packet) => !isVersionedPacketFamilyMember(packet.id));
   result.state.auditEvents = result.state.auditEvents.filter((event) =>
-    !event.packetId || !generatedPacketIds.has(event.packetId));
-  if (result.state.activePacketId && generatedPacketIds.has(result.state.activePacketId)) {
+    !event.packetId || !isVersionedPacketFamilyMember(event.packetId));
+  if (result.state.activePacketId && isVersionedPacketFamilyMember(result.state.activePacketId)) {
     result.state.activePacketId = null;
   }
   return result;


### PR DESCRIPTION
The autonomous strategy cycle legitimately advances recurring packet families from v1 to v2 and beyond. Its repository-backed tests reconstructed only the named v1 packets, causing the post-generation validation phase to fail against valid newer state.\n\nThis adds a pure, tested family matcher and uses it to isolate every generated version in both repository fixtures.\n\nLocal gates: typecheck; 5,104 tests plus the new regression test; strategy verification.