### PR TITLE
Normalize empty agent review summaries

### DIFF
--- a/.github/scripts/normalize-agent-review-response.mjs
+++ b/.github/scripts/normalize-agent-review-response.mjs
@@ -9,8 +9,8 @@ function objectRecord(value) {
 
 function canonicalResponse(response) {
   if (response.verdict !== 'approve' && response.verdict !== 'block') return null;
-  if (typeof response.summary !== 'string' || response.summary.trim().length === 0) {
-    throw new Error('Canonical agent review response requires a nonempty summary');
+  if (response.summary !== undefined && typeof response.summary !== 'string') {
+    throw new Error('Canonical agent review response summary must be a string when present');
   }
   if (!Array.isArray(response.blockers) ||
       response.blockers.some((blocker) => typeof blocker !== 'string' || blocker.trim().length === 0)) {
@@ -23,7 +23,10 @@ function canonicalResponse(response) {
   if (response.verdict === 'block' && blockers.length === 0) {
     throw new Error('Contradictory agent review response blocks without reporting a blocker');
   }
-  return { verdict: response.verdict, summary: response.summary.trim(), blockers };
+  const summary = (typeof response.summary === 'string' ? response.summary.trim() : '') || (response.verdict === 'approve'
+    ? 'The reviewer reported no material blockers.'
+    : 'The reviewer reported one or more material blockers.');
+  return { verdict: response.verdict, summary, blockers };
 }
 
 function categoryResponse(response) {

--- a/src/master-plan-controller/__tests__/agent-review-response.test.ts
+++ b/src/master-plan-controller/__tests__/agent-review-response.test.ts
@@ -17,6 +17,26 @@ describe('agent review response normalization', () => {
     });
   });
 
+  it('supplies a deterministic summary when constrained output leaves it empty', () => {
+    expect(normalizeAgentReviewResponse({
+      verdict: 'approve',
+      summary: '',
+      blockers: [],
+    })).toEqual({
+      verdict: 'approve',
+      summary: 'The reviewer reported no material blockers.',
+      blockers: [],
+    });
+  });
+
+  it('supplies a deterministic summary when constrained output omits it', () => {
+    expect(normalizeAgentReviewResponse({ verdict: 'approve', blockers: [] })).toEqual({
+      verdict: 'approve',
+      summary: 'The reviewer reported no material blockers.',
+      blockers: [],
+    });
+  });
+
   it('normalizes the pinned reviewer all-none category response to approval', () => {
     expect(normalizeAgentReviewResponse({
       blockers: {


### PR DESCRIPTION
Live canary runs showed that the constrained schema permits an empty summary even when verdict and blockers are valid. The normalizer was stricter than the schema and rejected those safe-to-normalize results.\n\nThis adds the failing canonical case and supplies a deterministic summary while preserving all verdict/blocker contradiction checks.\n\nLocal gates: targeted tests, typecheck, strategy verification.