### PR TITLE
Bound agent review retries by strategy

### DIFF
--- a/.github/scripts/normalize-agent-review-response.mjs
+++ b/.github/scripts/normalize-agent-review-response.mjs
@@ -42,7 +42,8 @@ function escapeLiteralControlsInsideJsonStrings(text) {
   return repaired;
 }
 
-function parseAgentReviewResponseJson(text) {
+export function parseAgentReviewResponseJson(text) {
+  if (typeof text !== 'string') throw new Error('Agent review response JSON must be text');
   try {
     return JSON.parse(text);
   } catch (originalError) {

--- a/.github/workflows/agent-review-request.yml
+++ b/.github/workflows/agent-review-request.yml
@@ -28,7 +28,7 @@ jobs:
           else
             pr_numbers="$(gh pr list --repo "$GITHUB_REPOSITORY" --state open --json number --jq '.[].number')"
           fi
-          review_strategies='qwen3-8b-categories-v3,qwen3-4b-categories-v3'
+          review_strategies='qwen3-14b-grounded-seed42-v8,qwen3-14b-grounded-seed7-v8'
           gh api \
             "repos/${GITHUB_REPOSITORY}/contents/.github/scripts/plan-agent-review-retry.mjs?ref=main" \
             --jq '.content' | base64 --decode > plan-agent-review-retry.mjs
@@ -48,7 +48,7 @@ jobs:
               continue
             fi
             gh api \
-              "repos/${GITHUB_REPOSITORY}/commits/${head_sha}/check-runs?check_name=agent-review" \
+              "repos/${GITHUB_REPOSITORY}/commits/${head_sha}/check-runs?check_name=agent-review&filter=all" \
               --jq '.check_runs' > agent-review-checks.json
             plan="$(node plan-agent-review-retry.mjs agent-review-checks.json \
               "$pr_number" "$head_sha" "$review_strategies")"

--- a/.github/workflows/agent-review.yml
+++ b/.github/workflows/agent-review.yml
@@ -5,9 +5,6 @@ on:
   pull_request_target:
     branches: [main]
     types: [opened, ready_for_review, reopened, synchronize]
-  pull_request_review:
-    branches: [main]
-    types: [submitted]
   workflow_dispatch:
     inputs:
       pr_number:
@@ -18,15 +15,11 @@ on:
         type: string
       review_strategy:
         required: false
-        default: qwen3-8b-categories-v3
+        default: qwen3-14b-grounded-seed42-v8
         type: choice
         options:
-          - qwen3-8b-categories-v3
-          - qwen3-8b-categories-seed7-v3
-          - qwen3-14b-grounded-seed7-v7
           - qwen3-14b-grounded-seed42-v8
           - qwen3-14b-grounded-seed7-v8
-          - qwen3-4b-categories-v3
 
 permissions:
   actions: write
@@ -49,16 +42,14 @@ jobs:
         uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9
         with:
           path: ${{ runner.temp }}/master-plan-independent-reviewer
-          key: agent-reviewer-b10242-qwen3-14b-grounded-seed7-v7
-          restore-keys: |
-            agent-reviewer-b10242-qwen3-8b-categories-v3
+          key: agent-reviewer-b10242-qwen3-14b-q4km
       - name: Require an independent GitHub agent review of the current head
         id: agent_review
         env:
           GH_TOKEN: ${{ github.token }}
           HEAD_SHA: ${{ github.event.pull_request.head.sha || inputs.head_sha }}
           PR_NUMBER: ${{ github.event.pull_request.number || inputs.pr_number }}
-          REVIEW_STRATEGY: ${{ inputs.review_strategy || 'qwen3-8b-categories-v3' }}
+          REVIEW_STRATEGY: ${{ inputs.review_strategy || 'qwen3-14b-grounded-seed42-v8' }}
         run: |
           set -euo pipefail
           pr_json="$(gh api "repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}")"
@@ -87,7 +78,7 @@ jobs:
             fi
           }
           existing_success="$(gh api \
-            "repos/${GITHUB_REPOSITORY}/commits/${HEAD_SHA}/check-runs?check_name=agent-review" \
+            "repos/${GITHUB_REPOSITORY}/commits/${HEAD_SHA}/check-runs?check_name=agent-review&filter=all" \
             | jq -r --arg external_id "agent-review:pr:${PR_NUMBER}:head:${HEAD_SHA}:" \
               '[.check_runs[] | select(.external_id != null and (.external_id | startswith($external_id)))]
                | any(.[]; .conclusion == "success")')"
@@ -157,42 +148,15 @@ jobs:
             | (cd "$reviewer_dir" && sha256sum --check -)
           tar -xzf "${reviewer_dir}/llama.tar.gz" -C "$reviewer_dir"
 
+          reviewer_model='Qwen3-14B-Q4_K_M.gguf'
+          reviewer_revision='530227a7d994db8eca5ab5ced2fb692b614357fd'
+          reviewer_checksum='500a8806e85ee9c83f3ae08420295592451379b4f8cf2d0f41c15dffeb6b81f0'
           case "$REVIEW_STRATEGY" in
-            qwen3-8b-categories-v3)
-              reviewer_model='Qwen3-8B-Q4_K_M.gguf'
-              reviewer_revision='7c41481f57cb95916b40956ab2f0b139b296d974'
-              reviewer_checksum='d98cdcbd03e17ce47681435b5150e34c1417f50b5c0019dd560e4882c5745785'
-              review_seed='42'
-              ;;
-            qwen3-8b-categories-seed7-v3)
-              reviewer_model='Qwen3-8B-Q4_K_M.gguf'
-              reviewer_revision='7c41481f57cb95916b40956ab2f0b139b296d974'
-              reviewer_checksum='d98cdcbd03e17ce47681435b5150e34c1417f50b5c0019dd560e4882c5745785'
-              review_seed='7'
-              ;;
-            qwen3-14b-grounded-seed7-v7)
-              reviewer_model='Qwen3-14B-Q4_K_M.gguf'
-              reviewer_revision='530227a7d994db8eca5ab5ced2fb692b614357fd'
-              reviewer_checksum='500a8806e85ee9c83f3ae08420295592451379b4f8cf2d0f41c15dffeb6b81f0'
-              review_seed='7'
-              ;;
             qwen3-14b-grounded-seed42-v8)
-              reviewer_model='Qwen3-14B-Q4_K_M.gguf'
-              reviewer_revision='530227a7d994db8eca5ab5ced2fb692b614357fd'
-              reviewer_checksum='500a8806e85ee9c83f3ae08420295592451379b4f8cf2d0f41c15dffeb6b81f0'
               review_seed='42'
               ;;
             qwen3-14b-grounded-seed7-v8)
-              reviewer_model='Qwen3-14B-Q4_K_M.gguf'
-              reviewer_revision='530227a7d994db8eca5ab5ced2fb692b614357fd'
-              reviewer_checksum='500a8806e85ee9c83f3ae08420295592451379b4f8cf2d0f41c15dffeb6b81f0'
               review_seed='7'
-              ;;
-            qwen3-4b-categories-v3)
-              reviewer_model='Qwen3-4B-Q4_K_M.gguf'
-              reviewer_revision='bc640142c66e1fdd12af0bd68f40445458f3869b'
-              reviewer_checksum='7485fe6f11af29433bc51cab58009521f205840f5b4ae3a32fa7f92e8534fdf5'
-              review_seed='42'
               ;;
             *)
               echo "Unsupported review strategy: $REVIEW_STRATEGY" >&2
@@ -332,4 +296,4 @@ jobs:
         uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9
         with:
           path: ${{ runner.temp }}/master-plan-independent-reviewer
-          key: agent-reviewer-b10242-qwen3-14b-grounded-seed7-v7
+          key: agent-reviewer-b10242-qwen3-14b-q4km

--- a/src/master-plan-controller/__tests__/agent-review-response.test.ts
+++ b/src/master-plan-controller/__tests__/agent-review-response.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from 'vitest';
 
 // The reviewer executes this dependency-free module directly on the hosted runner.
 // @ts-expect-error JavaScript workflow modules intentionally have no TypeScript declaration file.
-import { normalizeAgentReviewResponse } from '../../../.github/scripts/normalize-agent-review-response.mjs';
+import { normalizeAgentReviewResponse, parseAgentReviewResponseJson } from '../../../.github/scripts/normalize-agent-review-response.mjs';
 
 describe('agent review response normalization', () => {
   it('preserves a canonical approval', () => {
@@ -65,6 +65,18 @@ describe('agent review response normalization', () => {
       summary: 'The reviewer reported 1 material blocker.',
       blockers: ['correctness: The changed branch skips exact-head validation.'],
     });
+  });
+
+  it('repairs literal control characters inside constrained JSON string values', () => {
+    expect(parseAgentReviewResponseJson(
+      '{"blockers":{"security":"none","correctness":"line one\nline two"}}',
+    )).toEqual({
+      blockers: { security: 'none', correctness: 'line one\nline two' },
+    });
+  });
+
+  it('fails closed when invalid JSON is not a control character inside a string', () => {
+    expect(() => parseAgentReviewResponseJson('{"blockers":}')).toThrow();
   });
 
   it('fails closed for ambiguous or contradictory responses', () => {

--- a/src/master-plan-controller/__tests__/agent-review-retry.test.ts
+++ b/src/master-plan-controller/__tests__/agent-review-retry.test.ts
@@ -3,7 +3,7 @@ import { describe, expect, it } from 'vitest';
 import { planAgentReviewRetry } from '../../../.github/scripts/plan-agent-review-retry.mjs';
 
 const HEAD = '0123456789abcdef0123456789abcdef01234567';
-const STRATEGIES = ['qwen3-8b-categories-v3', 'qwen3-4b-categories-v3'] as const;
+const STRATEGIES = ['qwen3-14b-grounded-seed42-v8', 'qwen3-14b-grounded-seed7-v8'] as const;
 
 function check(
   strategy: string,
@@ -63,7 +63,7 @@ describe('agent-review retry planning', () => {
 
   it('permits a retry only when a new strategy signature is configured', () => {
     const oldFailure = check(STRATEGIES[0], 'completed', 'failure');
-    const revisedStrategies = ['qwen3-8b-categories-v4', 'qwen3-4b-categories-v4'] as const;
+    const revisedStrategies = ['qwen3-14b-grounded-seed42-v9', 'qwen3-14b-grounded-seed7-v9'] as const;
 
     expect(planAgentReviewRetry({
       prNumber: 42, headSha: HEAD, checks: [oldFailure], strategies: revisedStrategies,

--- a/src/master-plan-controller/__tests__/workflow-governance.test.ts
+++ b/src/master-plan-controller/__tests__/workflow-governance.test.ts
@@ -169,6 +169,7 @@ describe('blocking CI and governed workflows', () => {
     expect(agentReview).toContain('group: agent-review-${{ github.event.pull_request.number || inputs.pr_number }}-${{ github.event.pull_request.head.sha || inputs.head_sha }}');
     expect(agentReview).toContain('cancel-in-progress: false');
     expect(agentReview).toContain('pull_request_target:');
+    expect(agentReview).not.toContain('pull_request_review:');
     expect(agentReview).toContain('workflow_dispatch:');
     expect(agentReview).toContain('external_id');
     expect(agentReview).toContain('actions: write');
@@ -188,6 +189,9 @@ describe('blocking CI and governed workflows', () => {
     expect(agentReview).toContain('gh workflow run strategy-integrate-reviewed.yml');
     expect(agentReview).toContain('contents/.github/workflows/strategy-integrate-reviewed.yml?ref=main');
     expect(agentReview).toContain('Exact-head agent review is already successful; skipping duplicate run');
+    expect(agentReview).toContain(
+      'commits/${HEAD_SHA}/check-runs?check_name=agent-review&filter=all',
+    );
     expect(agentReview.indexOf('existing_success=')).toBeLessThan(agentReview.indexOf('check_id='));
     expect(agentReview).toContain('head.sha');
     expect(agentReview).toContain('llama-b10242-bin-ubuntu-x64.tar.gz');
@@ -196,9 +200,6 @@ describe('blocking CI and governed workflows', () => {
     expect(agentReview).toContain('Qwen3-14B-Q4_K_M.gguf');
     expect(agentReview).toContain('530227a7d994db8eca5ab5ced2fb692b614357fd');
     expect(agentReview).toContain('500a8806e85ee9c83f3ae08420295592451379b4f8cf2d0f41c15dffeb6b81f0');
-    expect(agentReview).toContain('Qwen3-4B-Q4_K_M.gguf');
-    expect(agentReview).toContain('bc640142c66e1fdd12af0bd68f40445458f3869b');
-    expect(agentReview).toContain('7485fe6f11af29433bc51cab58009521f205840f5b4ae3a32fa7f92e8534fdf5');
     expect(agentReview).toContain('review_strategy:');
     expect(agentReview).toContain('REVIEW_STRATEGY');
     expect(agentReview).toContain('output[title]');
@@ -229,13 +230,18 @@ describe('blocking CI and governed workflows', () => {
     expect(agentReview).toContain('required: ["security", "policy", "correctness", "safety", "material_omissions"]');
     expect(agentReview).toContain('Use the literal string none when a category has no material blocker');
     expect(agentReview).not.toContain('oneOf:');
-    expect(agentReview).toContain('qwen3-8b-categories-seed7-v3');
-    expect(agentReview).toContain('qwen3-14b-grounded-seed7-v7');
+    expect(agentReview).toContain('qwen3-14b-grounded-seed42-v8');
+    expect(agentReview).toContain('qwen3-14b-grounded-seed7-v8');
+    expect(agentReview).not.toContain('qwen3-14b-grounded-seed42-v7');
+    expect(agentReview).not.toContain('qwen3-14b-grounded-seed7-v7');
+    expect(agentReview).toContain("review_seed='42'");
     expect(agentReview).toContain("review_seed='7'");
     expect(agentReview).toContain('--argjson seed "$review_seed"');
     expect(agentReview).toContain('seed: $seed');
     expect(agentReview).toContain('only when changed lines directly establish it');
     expect(agentReview).toContain('Never invent code, privileges, policies, or missing validation');
+    expect(agentReview).toContain('key: agent-reviewer-b10242-qwen3-14b-q4km');
+    expect(agentReview).not.toContain('Qwen3-4B-Q4_K_M.gguf');
     expect(agentReview).toContain('prompt-injection-canary');
     expect(agentReview).toContain('grounding-canary.diff');
     expect(agentReview).toContain('grounding-canary.normalized.json');
@@ -243,6 +249,9 @@ describe('blocking CI and governed workflows', () => {
     expect(agentReview).not.toContain('example.invalid');
     expect(agentReview).not.toContain('make_adjudication_request');
     expect(agentReview).not.toContain('run_adjudication');
+    expect(agentReview).toContain(
+      'jq -e \'.verdict == "approve" and (.blockers | type == "array") and (.blockers | length == 0)\'',
+    );
     expect(agentReview).toContain('contents/.github/scripts/normalize-agent-review-response.mjs?ref=${GITHUB_SHA}');
     expect(agentReview).toContain('node normalize-agent-review-response.mjs');
     expect(agentReview).toContain('canary-review.raw.json');
@@ -261,9 +270,13 @@ describe('blocking CI and governed workflows', () => {
     expect(agentReviewRequest).toContain('gh workflow run agent-review.yml');
     expect(agentReviewRequest).toContain('GitHub-hosted pinned local-model fallback');
     expect(agentReviewRequest).toContain('Direct pull-request event already launches the fallback');
-    expect(agentReviewRequest).toContain('commits/${head_sha}/check-runs?check_name=agent-review');
+    expect(agentReviewRequest).toContain(
+      'commits/${head_sha}/check-runs?check_name=agent-review&filter=all',
+    );
     expect(agentReviewRequest).toContain('plan-agent-review-retry.mjs');
-    expect(agentReviewRequest).toContain('qwen3-8b-categories-v3,qwen3-4b-categories-v3');
+    expect(agentReviewRequest).toContain(
+      'qwen3-14b-grounded-seed42-v8,qwen3-14b-grounded-seed7-v8',
+    );
     expect(agentReviewRequest).toContain("'dispatch'");
     expect(agentReviewRequest).toContain('-f review_strategy="$strategy"');
     expect(agentReviewRequest).toContain('Review retry plan:');


### PR DESCRIPTION
## Outcome

- records exact-head reviewer strategy signatures on check runs
- requests GitHub's complete check history so exhausted strategies cannot be hidden by latest-only filtering
- retries only an untried configured strategy and stops after the bounded budget
- uses two checksum-pinned Qwen3 14B evidence-grounded v8 strategies with
  distinct seeds and one shared cache
- preserves a checksum-verified reviewer cache across fail-closed canary
  failures without caching partial or unverified downloads
- repairs only literal control characters inside otherwise JSON-constrained model strings,
  then continues to fail closed for every other malformed response
- rejects workflow-dispatch review attestations unless the workflow source is current `main`
- removes the redundant `pull_request_review` trigger so only merge-qualifying sources can create review checks
- requires both a benign grounding canary and an adversarial prompt-injection
  canary before a reviewer may inspect the real pull request
- preserves fail-closed exact-head checks

## Verification

- `npm test` — 258 files, 5,116 passed, 7 todo
- `npm run lint`
- `npm run strategy:verify`
