### PR TITLE
fix: support Guardian execution from fresh checkout

### DIFF
--- a/src/master-plan-controller/__tests__/runtime-adapters.test.ts
+++ b/src/master-plan-controller/__tests__/runtime-adapters.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { normalizeRepositoryPath, normalizeRepositoryText } from '../runtime-adapters.js';
+import { NodeFileSystem, normalizeRepositoryPath, normalizeRepositoryText } from '../runtime-adapters.js';
 
 describe('repository filesystem normalization', () => {
   it('returns portable repository paths from platform-specific paths', () => {
@@ -11,5 +11,9 @@ describe('repository filesystem normalization', () => {
   it('returns deterministic LF text from checked-out repository text', () => {
     expect(normalizeRepositoryText('first\r\nsecond\r\n')).toBe('first\nsecond\n');
     expect(normalizeRepositoryText('first\nsecond\n')).toBe('first\nsecond\n');
+  });
+
+  it('treats an absent output directory as an empty portable file set', async () => {
+    await expect(new NodeFileSystem('.').listFiles('strategy/results/')).resolves.toEqual([]);
   });
 });

--- a/src/master-plan-controller/runtime-adapters.ts
+++ b/src/master-plan-controller/runtime-adapters.ts
@@ -64,7 +64,12 @@ export class NodeFileSystem implements FileSystemPort {
         else if (entry.isFile()) results.push(normalizeRepositoryPath(relative(this.root, location)));
       }
     };
-    await walk(start);
+    try {
+      await walk(start);
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === 'ENOENT') return [];
+      throw error;
+    }
     return results.sort();
   }
 }


### PR DESCRIPTION
Treat a missing strategy/results directory as an empty result set, allowing the hourly Guardian workflow to execute its first bounded packet from a clean checkout.