### PR TITLE
Summarize Guardian Slack cycles

### DIFF
--- a/.github/workflows/guardian-cycle.yml
+++ b/.github/workflows/guardian-cycle.yml
@@ -42,14 +42,15 @@ jobs:
           if [[ -n "${GUARDIAN_MESSAGE}" ]]; then
             npm run guardian:inbox -- "$cycle_time" "${GUARDIAN_SENDER:-slack}" "$GUARDIAN_MESSAGE"
           fi
-          npm run guardian:progress -- "$cycle_time" cycle-started "The bounded Guardian cycle has started."
-          npm run strategy:generate -- "$cycle_time"
-          npm run strategy:execute -- "$cycle_time"
+          generation="$(npm run --silent strategy:generate -- "$cycle_time")"
+          execution="$(npm run --silent strategy:execute -- "$cycle_time")"
+          printf '%s\n' "$generation"
+          printf '%s\n' "$execution"
           npm run strategy:verify
           npm run docs:verify
           npm run lint
           npm test
-          npm run guardian:progress -- "$cycle_time" cycle-completed "The bounded Guardian cycle completed its deterministic checks."
+          npm run guardian:summary -- "$cycle_time" "$generation" "$execution"
           npm run guardian:communicate -- "$cycle_time"
       - name: Publish Guardian updates to Slack
         shell: bash

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -69,7 +69,8 @@ The operating body prepares, tests, and merges the resulting change after that d
 Guardian communication is collaborative rather than an update gate. A configured connector can ask
 for `status` or `help` and receive an immediate answer. Any other message is stored in the
 machine-readable Guardian inbox, included in the next bounded cycle, and answered through the
-Guardian update stream. Guardian publishes both cycle progress and completed-cycle updates.
+Guardian update stream. Guardian publishes one concise cycle summary explaining the executed work and
+its ranked-strategy reason, or why no work was eligible.
 
 When an exceptional escalation requires an intrinsically human act, Guardian posts one bounded
 question. Reply with `answer <question-id> <text>`; the answer is recorded as input, not treated as

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "guardian:status": "tsx src/master-plan-controller/cli/guardian-conversation-main.ts status",
     "guardian:inbox": "tsx src/master-plan-controller/cli/guardian-conversation-main.ts inbox",
     "guardian:progress": "tsx src/master-plan-controller/cli/guardian-conversation-main.ts progress",
+    "guardian:summary": "tsx src/master-plan-controller/cli/guardian-conversation-main.ts summary",
     "guardian:communicate": "tsx src/master-plan-controller/cli/guardian-conversation-main.ts communicate",
     "guardian:notify": "tsx src/master-plan-controller/cli/guardian-conversation-main.ts notify",
     "test": "vitest run",

--- a/src/master-plan-controller/README.md
+++ b/src/master-plan-controller/README.md
@@ -69,8 +69,8 @@ npm run guardian:status
 gh workflow run guardian-cycle.yml --ref main --raw-field sender=U_TEST --raw-field message="status"
 ```
 
-Then confirm that the workflow completes and that `strategy/guardian-updates.json` receives start
-and completion entries. After `SLACK_WEBHOOK_URL` is configured, the next successful cycle delivers
+Then confirm that the workflow completes and that `strategy/guardian-updates.json` receives one
+explanatory cycle summary. After `SLACK_WEBHOOK_URL` is configured, the next successful cycle delivers
 all pending updates and marks them delivered. Test `/guardian help`, a normal message, and a bounded
 answer to an actual Guardian question.
 

--- a/src/master-plan-controller/__tests__/guardian-conversation.test.ts
+++ b/src/master-plan-controller/__tests__/guardian-conversation.test.ts
@@ -44,20 +44,28 @@ describe('GuardianConversation', () => {
     await expect(guardian.readInbox()).resolves.toEqual([]);
   });
 
-  it('queues a message, answers it on the next cycle, and records progress updates', async () => {
+  it('queues a message, answers it on the next cycle, and records one explanatory cycle summary', async () => {
     const guardian = conversation();
 
     await expect(guardian.receive({
       id: 'slack-message-1', sender: 'U123', text: 'Focus the next report on preservation risks.', receivedAt: NOW,
     })).resolves.toMatchObject({ disposition: 'queued' });
-    await guardian.recordProgress('cycle-started', 'The bounded Guardian cycle has started.', NOW);
+    await guardian.recordCycleSummary({
+      generatedPacketIds: ['packet-preservation-mitigation-tabletop-run-1'],
+      selectedPacketId: 'packet-preservation-mitigation-tabletop-run-1',
+    }, {
+      status: 'executed', packetId: 'packet-preservation-mitigation-tabletop-run-1',
+    }, NOW);
     await guardian.processQueuedMessages(LATER);
 
     await expect(guardian.readInbox()).resolves.toMatchObject([{
       id: 'slack-message-1', status: 'answered', answeredAt: LATER,
     }]);
     await expect(guardian.readUpdates()).resolves.toEqual(expect.arrayContaining([
-      expect.objectContaining({ kind: 'progress', text: 'The bounded Guardian cycle has started.' }),
+      expect.objectContaining({
+        kind: 'summary',
+        text: expect.stringMatching(/executed packet-preservation-mitigation-tabletop-run-1.*highest-ranked eligible bounded packet/i),
+      }),
       expect.objectContaining({ kind: 'reply', inReplyTo: 'slack-message-1', occurredAt: LATER }),
       expect.objectContaining({ kind: 'question', questionId: 'human-decision:escalation-7' }),
     ]));
@@ -82,7 +90,7 @@ describe('GuardianConversation', () => {
       'strategy/guardian-inbox.json': '[]\n',
       'strategy/guardian-questions.json': '[]\n',
       'strategy/guardian-updates.json': JSON.stringify([{
-        id: 'guardian-update-1', kind: 'progress', text: 'Cycle complete.', occurredAt: NOW,
+        id: 'guardian-update-1', kind: 'summary', text: 'Cycle complete.', occurredAt: NOW,
       }]),
     });
     const network = new InMemoryNetwork({

--- a/src/master-plan-controller/__tests__/workflow-governance.test.ts
+++ b/src/master-plan-controller/__tests__/workflow-governance.test.ts
@@ -50,9 +50,11 @@ describe('streamlined update workflows', () => {
     expect(guardian).toContain('sender:');
     expect(guardian).toContain('npm run guardian:inbox');
     expect(guardian).toContain('npm run guardian:communicate');
+    expect(guardian).toContain('npm run guardian:summary');
     expect(guardian).toContain('npm run guardian:notify');
-    expect(guardian).toContain('npm run strategy:generate -- "$cycle_time"');
-    expect(guardian).toContain('npm run strategy:execute -- "$cycle_time"');
+    expect(guardian).not.toContain('npm run guardian:progress');
+    expect(guardian).toContain('npm run --silent strategy:generate -- "$cycle_time"');
+    expect(guardian).toContain('npm run --silent strategy:execute -- "$cycle_time"');
     expect(guardian).toContain('npm run strategy:verify');
     expect(guardian).toContain('npm run docs:verify');
     expect(guardian).toContain('npm run lint');

--- a/src/master-plan-controller/cli/guardian-conversation.ts
+++ b/src/master-plan-controller/cli/guardian-conversation.ts
@@ -42,6 +42,18 @@ export async function runGuardianConversationCli(
     await guardian.recordProgress(stage, text, now);
     return 'Guardian progress recorded.';
   }
+  if (command === 'summary') {
+    const [now, generationJson, executionJson] = values;
+    if (!now || !generationJson || !executionJson || values.length !== 3) {
+      usage('Usage: guardian summary <timestamp> <generation-json> <execution-json>');
+    }
+    await guardian.recordCycleSummary(
+      JSON.parse(generationJson) as { generatedPacketIds: string[]; selectedPacketId: string | null },
+      JSON.parse(executionJson) as { status: 'waiting' | 'executed' | 'already-executed'; packetId: string | null },
+      now,
+    );
+    return 'Guardian cycle summary recorded.';
+  }
   if (command === 'communicate') {
     const [now] = values;
     if (!now || values.length !== 1) usage('Usage: guardian communicate <timestamp>');
@@ -55,5 +67,5 @@ export async function runGuardianConversationCli(
     await guardian.deliverPendingUpdates(new SlackWebhookPublisher(network, slackWebhookUrl), now);
     return 'Guardian updates delivered to Slack.';
   }
-  usage('Usage: guardian <status|inbox|progress|communicate|notify> ...');
+  usage('Usage: guardian <status|inbox|progress|summary|communicate|notify> ...');
 }

--- a/src/master-plan-controller/guardian-conversation.ts
+++ b/src/master-plan-controller/guardian-conversation.ts
@@ -40,7 +40,7 @@ export interface GuardianQuestion extends GuardianQuestionRequest {
 
 export interface GuardianUpdate {
   id: string;
-  kind: 'progress' | 'reply' | 'question';
+  kind: 'progress' | 'summary' | 'reply' | 'question';
   text: string;
   occurredAt: Timestamp;
   inReplyTo?: string;
@@ -62,6 +62,16 @@ export interface GuardianMessageReply {
 
 export interface GuardianUpdatePublisher {
   publish(text: string): Promise<void>;
+}
+
+export interface GuardianCandidateGenerationSummary {
+  generatedPacketIds: string[];
+  selectedPacketId: string | null;
+}
+
+export interface GuardianPacketExecutionSummary {
+  status: 'waiting' | 'executed' | 'already-executed';
+  packetId: string | null;
 }
 
 function assertTimestamp(timestamp: Timestamp): void {
@@ -135,6 +145,25 @@ export class GuardianConversation {
       updates.push({ id, kind: 'progress', text: text.trim(), occurredAt: now });
       await this.write(UPDATES_PATH, updates);
     }
+  }
+
+  async recordCycleSummary(
+    generation: GuardianCandidateGenerationSummary,
+    execution: GuardianPacketExecutionSummary,
+    now: Timestamp,
+  ): Promise<void> {
+    assertTimestamp(now);
+    const updates = await this.readUpdates();
+    const id = updateId('summary', now);
+    if (updates.some((update) => update.id === id)) return;
+    const generated = generation.generatedPacketIds.length > 0
+      ? ` Generated ${generation.generatedPacketIds.length} candidate${generation.generatedPacketIds.length === 1 ? '' : 's'} from current strategy signals.`
+      : '';
+    const text = execution.status === 'executed' && execution.packetId
+      ? `Guardian cycle: executed ${execution.packetId}. Why: it was the highest-ranked eligible bounded packet under the current strategy.${generated}`
+      : `Guardian cycle: no packet executed. Why: no eligible bounded packet met the current trigger and gate conditions.${generated}`;
+    updates.push({ id, kind: 'summary', text, occurredAt: now });
+    await this.write(UPDATES_PATH, updates);
   }
 
   async processQueuedMessages(now: Timestamp): Promise<void> {


### PR DESCRIPTION
Replaces per-cycle start/completion Slack pings with one delivery-tracked summary of executed work and its priority rationale, or the reason no packet was eligible. Includes TDD coverage and documentation updates.