### PR TITLE
Keep Guardian cycles proactively productive

### DIFF
--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -18,7 +18,8 @@ updates are integrated after deterministic verification.
 3. Adjudicate relevant evidence and update affected hypotheses.
 4. Diagnose high-value uncertainty, bottlenecks, neglected portfolios, failure modes, and metric
    gaps.
-5. Generate eligible bounded work from stable packet series.
+5. Generate eligible bounded work from stable packet series; when passive triggers are quiet, fill a
+   proactive bounded backlog from feasible series.
 6. Rank the frontier with preservation receiving lexical priority over expansion.
 7. Execute one packet within its authority boundary.
 8. Integrate positive, negative, or null evidence and re-evaluate the graph.
@@ -70,7 +71,8 @@ Guardian communication is collaborative rather than an update gate. A configured
 for `status` or `help` and receive an immediate answer. Any other message is stored in the
 machine-readable Guardian inbox, included in the next bounded cycle, and answered through the
 Guardian update stream. Guardian publishes one concise cycle summary explaining the executed work and
-its ranked-strategy reason, or why no work was eligible.
+its ranked-strategy reason. A successful cycle does not idle for a passive trigger: it selects the
+highest-ranked feasible packet from the proactive bounded backlog.
 
 When an exceptional escalation requires an intrinsically human act, Guardian posts one bounded
 question. Reply with `answer <question-id> <text>`; the answer is recorded as input, not treated as
@@ -99,8 +101,9 @@ GitHub workflow-dispatch credential; neither belongs in this repository.
 - Repository updates use deterministic CI only.
 - Reviewed results since the current baseline: **2**.
 - Active work packets: **0**.
-- Guardian executes one bounded repository-only packet every hour.
-- Guardian publishes progress updates and accepts immediate status requests plus queued messages and answers through configured connectors.
+- Guardian executes the highest-ranked feasible bounded packet every hour and proactively fills an empty frontier.
+- Guardian publishes one explanatory cycle summary and accepts immediate status requests plus queued messages and answers through configured connectors.
+- The controller maintains a proactive bounded backlog; a successful cycle does not idle for a passive trigger.
 <!-- GENERATED:OPERATING-STATE:END -->
 
 ## Machine-readable state

--- a/src/master-plan-controller/README.md
+++ b/src/master-plan-controller/README.md
@@ -9,7 +9,7 @@ setup guide for connecting a Slack workspace.
 - `guardian-cycle.yml` runs the Guardian every hour and accepts optional `sender` and `message`
   workflow-dispatch inputs.
 - `strategy/guardian-inbox.json` holds queued messages; `guardian-questions.json` holds bounded
-  human questions; `guardian-updates.json` holds progress and replies until delivery succeeds.
+  human questions; `guardian-updates.json` holds one cycle summary and replies until delivery succeeds.
 - `SLACK_WEBHOOK_URL`, when configured as a GitHub Actions secret, publishes undelivered Guardian
   updates to Slack without blocking strategy work if Slack is unavailable.
 - `npm run guardian:status` answers the current operational status; `help`, a normal message, and
@@ -24,7 +24,7 @@ Complete these in order.
 
 1. In Slack, create an app for this workspace and give it a clear name such as `MASTER_PLAN
    Guardian`.
-2. Enable **Incoming Webhooks**, add one for the channel where progress updates should appear, and
+2. Enable **Incoming Webhooks**, add one for the channel where cycle summaries should appear, and
    copy the generated webhook URL.
 3. In GitHub, open this repository’s **Settings → Secrets and variables → Actions**, create a secret
    named `SLACK_WEBHOOK_URL`, and paste the webhook URL. Never commit it or place it in workflow

--- a/src/master-plan-controller/__tests__/guardian-conversation.test.ts
+++ b/src/master-plan-controller/__tests__/guardian-conversation.test.ts
@@ -64,11 +64,19 @@ describe('GuardianConversation', () => {
     await expect(guardian.readUpdates()).resolves.toEqual(expect.arrayContaining([
       expect.objectContaining({
         kind: 'summary',
-        text: expect.stringMatching(/executed packet-preservation-mitigation-tabletop-run-1.*highest-ranked eligible bounded packet/i),
+        text: expect.stringMatching(/completed packet-preservation-mitigation-tabletop-run-1.*What I did: generated 1 candidate and executed the highest-ranked feasible bounded task.*Why this: it ranked first after feasibility and preservation-first priority/i),
       }),
       expect.objectContaining({ kind: 'reply', inReplyTo: 'slack-message-1', occurredAt: LATER }),
       expect.objectContaining({ kind: 'question', questionId: 'human-decision:escalation-7' }),
     ]));
+  });
+
+  it('rejects a no-op cycle summary instead of normalizing an idle Guardian run', async () => {
+    const guardian = conversation();
+
+    await expect(guardian.recordCycleSummary({ generatedPacketIds: [], selectedPacketId: null }, {
+      status: 'waiting', packetId: null,
+    }, NOW)).rejects.toThrow(/must execute or confirm a bounded packet/i);
   });
 
   it('records a human answer to an open Guardian question without inventing an approval', async () => {

--- a/src/master-plan-controller/__tests__/repository-candidate-generation.test.ts
+++ b/src/master-plan-controller/__tests__/repository-candidate-generation.test.ts
@@ -95,6 +95,25 @@ describe('repository candidate generation', () => {
     expect(await fileSystem.readText('strategy/audit-log.json')).toBe(auditAfterFirst);
   });
 
+  it('fills an empty frontier with every feasible series, prioritizing the strongest bounded work', async () => {
+    const source = new NodeFileSystem('.');
+    const paths = [...(await source.listFiles('strategy/')), ...(await source.listFiles('docs/'))];
+    const snapshot = Object.fromEntries(await Promise.all(paths.map(async (path) => [path, await source.readText(path)])));
+    const fileSystem = new InMemoryFileSystem(snapshot);
+    const result = await runRepositoryCandidateGeneration(fileSystem, nextRepositoryTimestamp(snapshot));
+
+    expect(result.generatedPacketIds).toEqual(expect.arrayContaining([
+        'packet-durable-compute-fault-model-extension-run-1',
+        'packet-indicator-framework-comparison-run-1',
+        'packet-institutional-dependency-map-refresh-run-1',
+        'packet-preservation-mitigation-tabletop-run-2',
+        'packet-preservation-risk-register-refresh-run-2',
+    ]));
+    expect(result).toMatchObject({
+      selectedPacketId: 'packet-preservation-mitigation-tabletop-run-2',
+    });
+  });
+
   it('rejects an invalid supplied timestamp before writing', async () => {
     const initial = await repositorySnapshot();
     const fileSystem = new InMemoryFileSystem(initial);

--- a/src/master-plan-controller/__tests__/strategy-artifacts.test.ts
+++ b/src/master-plan-controller/__tests__/strategy-artifacts.test.ts
@@ -42,6 +42,7 @@ describe('unversioned repository strategy baseline', () => {
     expect(renderPortfolioBlock(bundle)).toContain('Consciousness epistemics');
     expect(renderGateBlock(bundle)).toContain('program-self-replication');
     expect(renderOperatingStateBlock(bundle)).toContain('automated stewardship');
+    expect(renderOperatingStateBlock(bundle)).toContain('proactive bounded backlog');
   });
 
   it('retains exactly four consolidated findings', async () => {

--- a/src/master-plan-controller/guardian-conversation.ts
+++ b/src/master-plan-controller/guardian-conversation.ts
@@ -153,15 +153,17 @@ export class GuardianConversation {
     now: Timestamp,
   ): Promise<void> {
     assertTimestamp(now);
+    if ((execution.status !== 'executed' && execution.status !== 'already-executed') || !execution.packetId) {
+      throw new Error('A successful Guardian cycle must execute or confirm a bounded packet');
+    }
     const updates = await this.readUpdates();
     const id = updateId('summary', now);
     if (updates.some((update) => update.id === id)) return;
-    const generated = generation.generatedPacketIds.length > 0
-      ? ` Generated ${generation.generatedPacketIds.length} candidate${generation.generatedPacketIds.length === 1 ? '' : 's'} from current strategy signals.`
-      : '';
-    const text = execution.status === 'executed' && execution.packetId
-      ? `Guardian cycle: executed ${execution.packetId}. Why: it was the highest-ranked eligible bounded packet under the current strategy.${generated}`
-      : `Guardian cycle: no packet executed. Why: no eligible bounded packet met the current trigger and gate conditions.${generated}`;
+    const workDescription = generation.generatedPacketIds.length > 0
+      ? `generated ${generation.generatedPacketIds.length} candidate${generation.generatedPacketIds.length === 1 ? '' : 's'} and executed`
+      : 'executed';
+    const action = execution.status === 'executed' ? 'completed' : 'confirmed the existing deterministic result for';
+    const text = `Guardian cycle: ${action} ${execution.packetId}. What I did: ${workDescription} the highest-ranked feasible bounded task. Why this: it ranked first after feasibility and preservation-first priority.`;
     updates.push({ id, kind: 'summary', text, occurredAt: now });
     await this.write(UPDATES_PATH, updates);
   }

--- a/src/master-plan-controller/packet-generation.ts
+++ b/src/master-plan-controller/packet-generation.ts
@@ -217,6 +217,32 @@ function recurringPacket(
   };
 }
 
+function proactiveRecurringPacket(
+  template: DiagnosticPacketTemplate,
+  state: StrategyState,
+): Omit<DiagnosticPacketTemplate, 'trigger' | 'recurrence'> | null {
+  const seriesId = template.seriesId;
+  if (!seriesId) throw new Error(`Recurring packet template ${template.id} has an invalid series identity`);
+  const familyPackets = state.packets
+    .filter((packet) => packet.seriesId === seriesId && Number.isSafeInteger(packet.runNumber) && packet.runNumber! > 0);
+  if (familyPackets.some((packet) => !['verified', 'invalidated', 'retired'].includes(packet.lifecycle))) {
+    return null;
+  }
+  const runNumber = familyPackets.reduce(
+    (highest, packet) => Math.max(highest, packet.runNumber ?? 0),
+    0,
+  ) + 1;
+  const { trigger: _trigger, recurrence: _recurrence, ...definition } = template;
+  return {
+    ...structuredClone(definition),
+    id: `${seriesId}-run-${runNumber}`,
+    seriesId,
+    runNumber,
+    retrySignature: `${template.retrySignature}-run-${runNumber}`,
+    deliverables: template.deliverables.map((deliverable) => `${deliverable}-run-${runNumber}`),
+  };
+}
+
 export class DiagnosticPacketGenerator implements PacketGeneratorPort {
   private readonly templates: DiagnosticPacketTemplate[];
 
@@ -246,6 +272,31 @@ export class DiagnosticPacketGenerator implements PacketGeneratorPort {
       .sort((left, right) => left.id.localeCompare(right.id))
       .map((template) => {
         if (template.recurrence?.kind === 'iterated') return recurringPacket(template, state, now);
+        if (state.packets.some((packet) => packet.id === template.id)) return null;
+        const { trigger: _trigger, recurrence: _recurrence, ...definition } = template;
+        return definition;
+      })
+      .filter((template): template is Omit<DiagnosticPacketTemplate, 'trigger' | 'recurrence'> => template !== null)
+      .slice(0, this.maximumCandidates)
+      .map((template) => ({
+        ...structuredClone(template),
+        lifecycle: 'eligible' as const,
+        attempt: 0,
+        reviewedAt: now,
+      }));
+  }
+
+  /**
+   * Keeps a bounded autonomous backlog moving when passive diagnostic triggers
+   * are quiet. Existing non-terminal work is never duplicated.
+   */
+  async generateProactiveBacklog(
+    state: StrategyState,
+    now: Timestamp,
+  ): Promise<WorkPacket[]> {
+    return this.templates
+      .map((template) => {
+        if (template.recurrence?.kind === 'iterated') return proactiveRecurringPacket(template, state);
         if (state.packets.some((packet) => packet.id === template.id)) return null;
         const { trigger: _trigger, recurrence: _recurrence, ...definition } = template;
         return definition;

--- a/src/master-plan-controller/repository-candidate-generation.ts
+++ b/src/master-plan-controller/repository-candidate-generation.ts
@@ -35,8 +35,11 @@ export async function runRepositoryCandidateGeneration(
     return { generatedPacketIds: [], selectedPacketId: frontier.ranked[0].packet.id };
   }
 
-  const candidates = await new DiagnosticPacketGenerator(bundle.packetTemplates)
-    .generate(bundle.state, frontier.diagnosis, now);
+  const generator = new DiagnosticPacketGenerator(bundle.packetTemplates);
+  const diagnosticCandidates = await generator.generate(bundle.state, frontier.diagnosis, now);
+  const candidates = diagnosticCandidates.length > 0
+    ? diagnosticCandidates
+    : await generator.generateProactiveBacklog(bundle.state, now);
   const accepted: WorkPacket[] = [];
   for (const packet of candidates) {
     const errors = workPacketValidationErrors(packet, bundle.state, now);
@@ -46,7 +49,9 @@ export async function runRepositoryCandidateGeneration(
     if (errors.length > 0) throw new Error(`Generated packet ${packet.id} failed validation: ${errors.join('; ')}`);
     accepted.push(structuredClone(packet));
   }
-  if (accepted.length === 0) return { generatedPacketIds: [], selectedPacketId: null };
+  if (accepted.length === 0) {
+    throw new Error('No bounded work packet is available after proactive backlog generation');
+  }
 
   const state = {
     ...bundle.state,
@@ -58,6 +63,10 @@ export async function runRepositoryCandidateGeneration(
   if (after.errors.length > 0) throw new Error(`Generated strategy failed verification: ${after.errors.join('; ')}`);
 
   frontier = new Controller(state, bundle.config).evaluate(state, now);
+  const selectedPacketId = frontier.ranked[0]?.packet.id;
+  if (!selectedPacketId) {
+    throw new Error('Proactive backlog generation did not produce a feasible bounded packet');
+  }
   const [packetsText, auditText] = await Promise.all([
     fileSystem.readText('strategy/work-packets.json'),
     fileSystem.readText('strategy/audit-log.json'),
@@ -72,6 +81,6 @@ export async function runRepositoryCandidateGeneration(
   );
   return {
     generatedPacketIds: accepted.map((packet) => packet.id),
-    selectedPacketId: frontier.ranked[0]?.packet.id ?? null,
+    selectedPacketId,
   };
 }

--- a/src/master-plan-controller/roadmap.ts
+++ b/src/master-plan-controller/roadmap.ts
@@ -58,8 +58,9 @@ export function renderOperatingStateBlock(bundle: RepositoryStrategyBundle): str
     '- Repository updates use deterministic CI only.',
     `- Reviewed results since the current baseline: **${bundle.state.governance.reviewedResultCount}**.`,
     `- Active work packets: **${activePackets}**.`,
-    '- Guardian executes one bounded repository-only packet every hour.',
-    '- Guardian publishes progress updates and accepts immediate status requests plus queued messages and answers through configured connectors.',
+    '- Guardian executes the highest-ranked feasible bounded packet every hour and proactively fills an empty frontier.',
+    '- Guardian publishes one explanatory cycle summary and accepts immediate status requests plus queued messages and answers through configured connectors.',
+    '- The controller maintains a proactive bounded backlog; a successful cycle does not idle for a passive trigger.',
   ].join('\n');
 }
 


### PR DESCRIPTION
## Summary\n- fill an empty Guardian frontier with feasible recurring bounded work\n- select preservation-first ranked work instead of normalizing idle cycles\n- make cycle summaries state the completed work and strategy rationale\n\n## Verification\n- npm test\n- npm run lint\n- npm run docs:verify\n- npm run strategy:verify