### PR TITLE
Run Guardian cycles on host

### DIFF
--- a/.github/workflows/guardian-cycle.yml
+++ b/.github/workflows/guardian-cycle.yml
@@ -1,77 +1,13 @@
-name: Guardian cycle
+name: Guardian cycle handoff
 
 on:
-  schedule:
-    - cron: '17 * * * *'
   workflow_dispatch:
-    inputs:
-      sender:
-        description: "Guardian message sender (for example, a Slack member ID)"
-        required: false
-        type: string
-      message:
-        description: "Message or answer <question-id> <text> for the Guardian"
-        required: false
-        type: string
 
 permissions:
-  contents: write
-
-concurrency:
-  group: guardian-cycle-main
-  cancel-in-progress: false
+  contents: read
 
 jobs:
-  run-bounded-cycle:
+  host-owned-guardian:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
-        with:
-          node-version: 24
-          cache: npm
-      - run: npm ci
-      - name: Generate, execute, and integrate one bounded Guardian packet
-        shell: bash
-        env:
-          GUARDIAN_SENDER: ${{ inputs.sender }}
-          GUARDIAN_MESSAGE: ${{ inputs.message }}
-        run: |
-          set -euo pipefail
-          cycle_time="$(date --utc +%Y-%m-%dT%H:%M:%S.000Z)"
-          if [[ -n "${GUARDIAN_MESSAGE}" ]]; then
-            npm run guardian:inbox -- "$cycle_time" "${GUARDIAN_SENDER:-slack}" "$GUARDIAN_MESSAGE"
-          fi
-          generation="$(npm run --silent strategy:generate -- "$cycle_time")"
-          execution="$(npm run --silent strategy:execute -- "$cycle_time")"
-          printf '%s\n' "$generation"
-          printf '%s\n' "$execution"
-          npm run strategy:verify
-          npm run docs:verify
-          npm run lint
-          npm test
-          npm run guardian:summary -- "$cycle_time" "$generation" "$execution"
-          npm run guardian:communicate -- "$cycle_time"
-      - name: Publish Guardian updates to Slack
-        shell: bash
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
-        run: |
-          set -euo pipefail
-          if [[ -z "${SLACK_WEBHOOK_URL}" ]]; then
-            exit 0
-          fi
-          cycle_time="$(date --utc +%Y-%m-%dT%H:%M:%S.000Z)"
-          npm run guardian:notify -- "$cycle_time" || echo "Slack delivery failed; pending updates will be retried."
-      - name: Commit a changed cycle
-        shell: bash
-        run: |
-          set -euo pipefail
-          if git diff --quiet; then
-            exit 0
-          fi
-          git config user.name 'MASTER_PLAN Guardian'
-          git config user.email 'guardian@users.noreply.github.com'
-          git add docs strategy
-          git commit -m 'chore: run guardian cycle'
-          git push origin HEAD:main
+      - run: echo "The authenticated host runs Guardian cycles; CI validates its resulting commits."

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -24,6 +24,16 @@ updates are integrated after deterministic verification.
 7. Execute one packet within its authority boundary.
 8. Integrate positive, negative, or null evidence and re-evaluate the graph.
 
+## Host Guardian
+
+The authenticated repository host, not GitHub Actions, owns scheduled Guardian
+execution. Its cron entry runs `scripts/run-host-guardian-cycle.sh`, which
+locks a dedicated Git worktree, invokes Codex with workspace-write sandboxing,
+then performs one deterministic bounded cycle. A changed cycle is pushed on a
+Guardian branch; CI remains responsible for deterministic validation of that
+commit. The host's Codex and GitHub CLI credentials stay in the service
+account and are never added to this repository or passed to CI.
+
 All filesystem, time, network, process, and command-line behavior crosses injectable interfaces.
 Methods receive referenced timestamps from callers; strategy logic does not read ambient time.
 

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "type": "module",
   "scripts": {
     "start": "tsx src/agent-runtime/main.ts",
+    "guardian:host-cycle": "tsx src/master-plan-controller/cli/host-guardian-supervisor-main.ts",
     "build": "tsc",
     "lint": "tsc --noEmit",
     "strategy:verify": "tsx src/master-plan-controller/cli/verify-strategy.ts",

--- a/scripts/run-host-guardian-cycle.sh
+++ b/scripts/run-host-guardian-cycle.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+# Cron entry point: serialized, isolated host Guardian worktree with CI left as
+# the deterministic verification boundary.
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+runtime_dir="$repo_root/.guardian"
+worktree_dir="$runtime_dir/host-worktree"
+branch="guardian/host-supervisor"
+lock_file="$runtime_dir/host-guardian.lock"
+repository="${MASTER_PLAN_GITHUB_REPOSITORY:-rookdaemon/MASTER_PLAN}"
+
+mkdir -p "$runtime_dir"
+exec 9>"$lock_file"
+flock -n 9 || exit 0
+
+if test -n "$(git -C "$repo_root" status --porcelain)"; then
+  echo "Refusing to run: primary checkout has uncommitted changes." >&2
+  exit 1
+fi
+git -C "$repo_root" fetch origin main
+if test -e "$worktree_dir/.git"; then
+  test -z "$(git -C "$worktree_dir" status --porcelain)"
+  git -C "$worktree_dir" fetch origin main
+  git -C "$worktree_dir" reset --hard origin/main
+else
+  git -C "$repo_root" worktree add -B "$branch" "$worktree_dir" origin/main
+fi
+if test ! -e "$worktree_dir/node_modules"; then ln -s "$repo_root/node_modules" "$worktree_dir/node_modules"; fi
+
+if test "$(gh pr list --repo "$repository" --head "$branch" --state open --json number --jq 'length')" -gt 0; then
+  echo "Guardian PR remains open; waiting for deterministic CI."
+  exit 0
+fi
+
+git -C "$worktree_dir" config user.name 'MASTER_PLAN Guardian'
+git -C "$worktree_dir" config user.email 'guardian@users.noreply.github.com'
+(
+  cd "$worktree_dir"
+  npm run guardian:host-cycle
+  if test -n "$(git status --porcelain)"; then
+    git add docs strategy
+    git commit -m 'chore: run host guardian cycle'
+  fi
+  if test "$(git rev-list --count origin/main..HEAD)" -gt 0; then
+    git push --set-upstream origin "$branch"
+    gh pr create --base main --head "$branch" --title 'chore: run host guardian cycle' \
+      --body 'Host-owned Codex Guardian cycle; deterministic CI validates the result.'
+  fi
+)

--- a/src/master-plan-controller/__tests__/host-guardian-supervisor.test.ts
+++ b/src/master-plan-controller/__tests__/host-guardian-supervisor.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from 'vitest';
+import { runHostGuardianSupervisor, type HostGuardianConfig } from '../host-guardian-supervisor.js';
+import { InMemoryClock, InMemoryFileSystem, InMemoryProcess } from '../testing/in-memory-adapters.js';
+
+const NOW = '2026-08-25T12:00:00.000Z';
+const config: HostGuardianConfig = {
+  workingDirectory: '/workspace',
+  statePath: '.guardian/host-guardian-state.json',
+  intervalMs: 60 * 60 * 1_000,
+  codexModel: 'gpt-5.6-sol',
+};
+
+describe('host Guardian supervisor', () => {
+  it('runs one Codex-led, deterministic Guardian cycle and records its caller-supplied timestamp', async () => {
+    const fs = new InMemoryFileSystem();
+    const process = new InMemoryProcess(Array.from({ length: 8 }, () => ({ exitCode: 0, stdout: '{}', stderr: '' })));
+
+    const result = await runHostGuardianSupervisor({ fs, process, clock: new InMemoryClock(NOW) }, config);
+
+    expect(result.ran).toBe(true);
+    expect(process.requests).toEqual([
+      expect.objectContaining({ command: 'codex', args: expect.arrayContaining(['exec', '--sandbox', 'workspace-write', '--approve-for-me', '--ephemeral', '-m', 'gpt-5.6-sol']) }),
+      expect.objectContaining({ command: 'npm', args: ['run', 'strategy:generate', '--', NOW] }),
+      expect.objectContaining({ command: 'npm', args: ['run', 'strategy:execute', '--', NOW] }),
+      expect.objectContaining({ command: 'npm', args: ['run', 'strategy:verify'] }),
+      expect.objectContaining({ command: 'npm', args: ['run', 'docs:verify'] }),
+      expect.objectContaining({ command: 'npm', args: ['run', 'lint'] }),
+      expect.objectContaining({ command: 'npm', args: ['test'] }),
+      expect.objectContaining({ command: 'npm', args: ['run', 'guardian:summary', '--', NOW, '{}', '{}'] }),
+    ]);
+    expect(JSON.parse(await fs.readText(config.statePath))).toEqual({ version: 1, completedAt: NOW });
+  });
+
+  it('does not repeat a cycle before its configured interval', async () => {
+    const fs = new InMemoryFileSystem({
+      [config.statePath]: JSON.stringify({ version: 1, completedAt: '2026-08-25T11:30:00.000Z' }),
+    });
+    const process = new InMemoryProcess();
+
+    const result = await runHostGuardianSupervisor({ fs, process, clock: new InMemoryClock(NOW) }, config);
+
+    expect(result).toEqual({ ran: false });
+    expect(process.requests).toEqual([]);
+  });
+
+  it('does not record a failed Codex or deterministic command as complete', async () => {
+    const fs = new InMemoryFileSystem();
+    const process = new InMemoryProcess([{ exitCode: 1, stdout: '', stderr: 'authentication unavailable' }]);
+
+    await expect(runHostGuardianSupervisor({ fs, process, clock: new InMemoryClock(NOW) }, config))
+      .rejects.toThrow('host guardian command failed: authentication unavailable');
+    await expect(fs.readText(config.statePath)).rejects.toThrow('File not found');
+  });
+});

--- a/src/master-plan-controller/__tests__/workflow-governance.test.ts
+++ b/src/master-plan-controller/__tests__/workflow-governance.test.ts
@@ -42,25 +42,14 @@ describe('streamlined update workflows', () => {
     }
   });
 
-  it('runs one bounded Guardian cycle every hour without a reviewer or pull-request detour', async () => {
+  it('keeps Guardian execution off CI and leaves a read-only handoff workflow', async () => {
     const guardian = await fileSystem.readText('.github/workflows/guardian-cycle.yml');
-    expect(guardian).toContain("cron: '17 * * * *'");
     expect(guardian).toContain('workflow_dispatch:');
-    expect(guardian).toContain('message:');
-    expect(guardian).toContain('sender:');
-    expect(guardian).toContain('npm run guardian:inbox');
-    expect(guardian).toContain('npm run guardian:communicate');
-    expect(guardian).toContain('npm run guardian:summary');
-    expect(guardian).toContain('npm run guardian:notify');
-    expect(guardian).not.toContain('npm run guardian:progress');
-    expect(guardian).toContain('npm run --silent strategy:generate -- "$cycle_time"');
-    expect(guardian).toContain('npm run --silent strategy:execute -- "$cycle_time"');
-    expect(guardian).toContain('npm run strategy:verify');
-    expect(guardian).toContain('npm run docs:verify');
-    expect(guardian).toContain('npm run lint');
-    expect(guardian).toContain('npm test');
-    expect(guardian).toContain('git push origin HEAD:main');
-    expect(guardian).not.toMatch(/agent.review|copilot|pull request|gh pr/i);
+    expect(guardian).not.toContain('schedule:');
+    expect(guardian).toContain('contents: read');
+    expect(guardian).toContain('authenticated host runs Guardian cycles');
+    expect(guardian).not.toContain('npm run strategy:');
+    expect(guardian).not.toContain('git push');
   });
 
   it('documents CI-only update handling without independent agent-review requirements', async () => {

--- a/src/master-plan-controller/cli/host-guardian-supervisor-main.ts
+++ b/src/master-plan-controller/cli/host-guardian-supervisor-main.ts
@@ -1,0 +1,21 @@
+import { NodeFileSystem, NodeProcess, SystemClock } from '../runtime-adapters.js';
+import { runHostGuardianSupervisor } from '../host-guardian-supervisor.js';
+
+async function main(): Promise<void> {
+  const workingDirectory = process.cwd();
+  const result = await runHostGuardianSupervisor(
+    { fs: new NodeFileSystem(workingDirectory), process: new NodeProcess(), clock: new SystemClock() },
+    {
+      workingDirectory,
+      statePath: '.guardian/host-guardian-state.json',
+      intervalMs: 60 * 60 * 1_000,
+      codexModel: process.env['MASTER_PLAN_CODEX_MODEL'] ?? 'gpt-5.6-sol',
+    },
+  );
+  process.stdout.write(`${JSON.stringify(result)}\n`);
+}
+
+void main().catch((error: unknown) => {
+  process.stderr.write(`${error instanceof Error ? error.message : String(error)}\n`);
+  process.exitCode = 1;
+});

--- a/src/master-plan-controller/host-guardian-supervisor.ts
+++ b/src/master-plan-controller/host-guardian-supervisor.ts
@@ -1,0 +1,92 @@
+/** Host-owned, one-shot Guardian scheduler. All host effects enter via ports. */
+import type { ClockPort, FileSystemPort, ProcessPort, ProcessRequest } from './ports.js';
+
+export interface HostGuardianConfig {
+  workingDirectory: string;
+  statePath: string;
+  intervalMs: number;
+  codexModel: string;
+}
+
+export interface HostGuardianDeps {
+  fs: FileSystemPort;
+  process: ProcessPort;
+  clock: ClockPort;
+}
+
+interface State { version: 1; completedAt?: string; }
+
+export async function runHostGuardianSupervisor(
+  deps: HostGuardianDeps,
+  config: HostGuardianConfig,
+): Promise<{ ran: boolean }> {
+  const now = deps.clock.now();
+  assertTimestamp(now);
+  const state = await loadState(deps.fs, config.statePath);
+  if (!isDue(state.completedAt, config.intervalMs, now)) return { ran: false };
+
+  let generation = '';
+  let execution = '';
+  for (const request of commands(now, config)) {
+    const result = await deps.process.run(request);
+    if (result.exitCode !== 0) {
+      throw new Error(`host guardian command failed: ${result.stderr.trim() || result.stdout.trim() || `exit code ${result.exitCode}`}`);
+    }
+    if (request.args.includes('strategy:generate')) generation = result.stdout.trim();
+    if (request.args.includes('strategy:execute')) execution = result.stdout.trim();
+  }
+  const summary = await deps.process.run({
+    command: 'npm', args: ['run', 'guardian:summary', '--', now, generation, execution], cwd: config.workingDirectory,
+  });
+  if (summary.exitCode !== 0) {
+    throw new Error(`host guardian command failed: ${summary.stderr.trim() || summary.stdout.trim() || `exit code ${summary.exitCode}`}`);
+  }
+
+  await deps.fs.writeText(config.statePath, `${JSON.stringify({ version: 1, completedAt: now })}\n`);
+  return { ran: true };
+}
+
+function commands(now: string, config: HostGuardianConfig): ProcessRequest[] {
+  const cwd = config.workingDirectory;
+  const prompt = [
+    'You are the host-owned Master Plan Guardian.',
+    'Inspect the current strategy and complete exactly one bounded, repository-scoped improvement.',
+    'Respect strategy authority boundaries and do not use credentials, push, commit, alter CI, or perform external actions.',
+    'Work only in this worktree. If no safe material improvement is available, make no change and exit.',
+  ].join(' ');
+  const npm = (args: string[]): ProcessRequest => ({ command: 'npm', args, cwd });
+  const agent: ProcessRequest = {
+    command: 'codex',
+    args: ['exec', '--sandbox', 'workspace-write', '--approve-for-me', '--json', '--color', 'never', '--ephemeral', '-m', config.codexModel, '-C', cwd, prompt],
+    cwd,
+  };
+  const generation = npm(['run', 'strategy:generate', '--', now]);
+  const execution = npm(['run', 'strategy:execute', '--', now]);
+  const verification = [
+    npm(['run', 'strategy:verify']), npm(['run', 'docs:verify']), npm(['run', 'lint']), npm(['test']),
+  ];
+  return [agent, generation, execution, ...verification];
+}
+
+async function loadState(fs: FileSystemPort, path: string): Promise<State> {
+  try {
+    const parsed = JSON.parse(await fs.readText(path)) as Partial<State>;
+    if (parsed.version !== 1 || (parsed.completedAt !== undefined && typeof parsed.completedAt !== 'string')) {
+      throw new Error('host Guardian state is malformed');
+    }
+    if (parsed.completedAt) assertTimestamp(parsed.completedAt);
+    return { version: 1, ...(parsed.completedAt ? { completedAt: parsed.completedAt } : {}) };
+  } catch (error) {
+    if (error instanceof Error && error.message.startsWith('File not found:')) return { version: 1 };
+    throw error;
+  }
+}
+
+function isDue(last: string | undefined, intervalMs: number, now: string): boolean {
+  if (!Number.isSafeInteger(intervalMs) || intervalMs <= 0) throw new Error('host Guardian interval must be positive');
+  return !last || Date.parse(now) - Date.parse(last) >= intervalMs;
+}
+
+function assertTimestamp(value: string): void {
+  if (Number.isNaN(Date.parse(value))) throw new Error('A valid caller-supplied timestamp is required');
+}


### PR DESCRIPTION
Moves the scheduled Guardian execution from GitHub Actions to this authenticated host. A cron-compatible, locked worktree runner invokes Codex with workspace-write sandboxing and submits any changed cycle for deterministic CI validation.