### PR TITLE
Handle absent host Guardian state

### DIFF
--- a/src/master-plan-controller/__tests__/host-guardian-supervisor.test.ts
+++ b/src/master-plan-controller/__tests__/host-guardian-supervisor.test.ts
@@ -43,6 +43,18 @@ describe('host Guardian supervisor', () => {
     expect(process.requests).toEqual([]);
   });
 
+  it('treats the Node filesystem ENOENT form as an absent runtime state file', async () => {
+    const missingStateFs = {
+      readText: async () => { throw Object.assign(new Error('ENOENT'), { code: 'ENOENT' }); },
+      writeText: async () => undefined,
+      listFiles: async () => [],
+    };
+    const process = new InMemoryProcess(Array.from({ length: 8 }, () => ({ exitCode: 0, stdout: '{}', stderr: '' })));
+
+    await expect(runHostGuardianSupervisor({ fs: missingStateFs, process, clock: new InMemoryClock(NOW) }, config))
+      .resolves.toEqual({ ran: true });
+  });
+
   it('does not record a failed Codex or deterministic command as complete', async () => {
     const fs = new InMemoryFileSystem();
     const process = new InMemoryProcess([{ exitCode: 1, stdout: '', stderr: 'authentication unavailable' }]);

--- a/src/master-plan-controller/host-guardian-supervisor.ts
+++ b/src/master-plan-controller/host-guardian-supervisor.ts
@@ -77,9 +77,16 @@ async function loadState(fs: FileSystemPort, path: string): Promise<State> {
     if (parsed.completedAt) assertTimestamp(parsed.completedAt);
     return { version: 1, ...(parsed.completedAt ? { completedAt: parsed.completedAt } : {}) };
   } catch (error) {
-    if (error instanceof Error && error.message.startsWith('File not found:')) return { version: 1 };
+    if (isMissingFile(error)) return { version: 1 };
     throw error;
   }
+}
+
+function isMissingFile(error: unknown): boolean {
+  return error instanceof Error && (
+    error.message.startsWith('File not found:') ||
+    (typeof (error as NodeJS.ErrnoException).code === 'string' && (error as NodeJS.ErrnoException).code === 'ENOENT')
+  );
 }
 
 function isDue(last: string | undefined, intervalMs: number, now: string): boolean {


### PR DESCRIPTION
Makes the host Guardian scheduler accept Node filesystem ENOENT for its initial ignored runtime-state file.