### PR TITLE
Ignore host Guardian dependency symlink

### DIFF
--- a/scripts/run-host-guardian-cycle.sh
+++ b/scripts/run-host-guardian-cycle.sh
@@ -20,7 +20,7 @@ if test -n "$(git -C "$repo_root" status --porcelain)"; then
 fi
 git -C "$repo_root" fetch origin main
 if test -e "$worktree_dir/.git"; then
-  test -z "$(git -C "$worktree_dir" status --porcelain)"
+  test -z "$(git -C "$worktree_dir" status --porcelain --untracked-files=no)"
   git -C "$worktree_dir" fetch origin main
   git -C "$worktree_dir" reset --hard origin/main
 else

--- a/src/master-plan-controller/__tests__/host-guardian-supervisor.test.ts
+++ b/src/master-plan-controller/__tests__/host-guardian-supervisor.test.ts
@@ -28,6 +28,7 @@ describe('host Guardian supervisor', () => {
       expect.objectContaining({ command: 'npm', args: ['test'] }),
       expect.objectContaining({ command: 'npm', args: ['run', 'guardian:summary', '--', NOW, '{}', '{}'] }),
     ]);
+    expect(process.requests[0].args.at(-1)).toContain('Only modify docs/ and strategy/.');
     expect(JSON.parse(await fs.readText(config.statePath))).toEqual({ version: 1, completedAt: NOW });
   });
 

--- a/src/master-plan-controller/host-guardian-supervisor.ts
+++ b/src/master-plan-controller/host-guardian-supervisor.ts
@@ -51,6 +51,7 @@ function commands(now: string, config: HostGuardianConfig): ProcessRequest[] {
   const prompt = [
     'You are the host-owned Master Plan Guardian.',
     'Inspect the current strategy and complete exactly one bounded, repository-scoped improvement.',
+    'Only modify docs/ and strategy/.',
     'Respect strategy authority boundaries and do not use credentials, push, commit, alter CI, or perform external actions.',
     'Work only in this worktree. If no safe material improvement is available, make no change and exit.',
   ].join(' ');


### PR DESCRIPTION
Prevents the isolated host worktree's local node_modules symlink from blocking Guardian startup, while keeping tracked-change checks strict.