### PR TITLE
Use compatible Codex approval mode

### DIFF
--- a/src/master-plan-controller/__tests__/host-guardian-supervisor.test.ts
+++ b/src/master-plan-controller/__tests__/host-guardian-supervisor.test.ts
@@ -19,7 +19,7 @@ describe('host Guardian supervisor', () => {
 
     expect(result.ran).toBe(true);
     expect(process.requests).toEqual([
-      expect.objectContaining({ command: 'codex', args: expect.arrayContaining(['exec', '--sandbox', 'workspace-write', '--approve-for-me', '--ephemeral', '-m', 'gpt-5.6-sol']) }),
+      expect.objectContaining({ command: 'codex', args: expect.arrayContaining(['exec', '--approve-for-me', '--ephemeral', '-m', 'gpt-5.6-sol']) }),
       expect.objectContaining({ command: 'npm', args: ['run', 'strategy:generate', '--', NOW] }),
       expect.objectContaining({ command: 'npm', args: ['run', 'strategy:execute', '--', NOW] }),
       expect.objectContaining({ command: 'npm', args: ['run', 'strategy:verify'] }),
@@ -28,6 +28,7 @@ describe('host Guardian supervisor', () => {
       expect.objectContaining({ command: 'npm', args: ['test'] }),
       expect.objectContaining({ command: 'npm', args: ['run', 'guardian:summary', '--', NOW, '{}', '{}'] }),
     ]);
+    expect(process.requests[0].args).not.toContain('--sandbox');
     expect(process.requests[0].args.at(-1)).toContain('Only modify docs/ and strategy/.');
     expect(JSON.parse(await fs.readText(config.statePath))).toEqual({ version: 1, completedAt: NOW });
   });

--- a/src/master-plan-controller/host-guardian-supervisor.ts
+++ b/src/master-plan-controller/host-guardian-supervisor.ts
@@ -58,7 +58,7 @@ function commands(now: string, config: HostGuardianConfig): ProcessRequest[] {
   const npm = (args: string[]): ProcessRequest => ({ command: 'npm', args, cwd });
   const agent: ProcessRequest = {
     command: 'codex',
-    args: ['exec', '--sandbox', 'workspace-write', '--approve-for-me', '--json', '--color', 'never', '--ephemeral', '-m', config.codexModel, '-C', cwd, prompt],
+    args: ['exec', '--approve-for-me', '--json', '--color', 'never', '--ephemeral', '-m', config.codexModel, '-C', cwd, prompt],
     cwd,
   };
   const generation = npm(['run', 'strategy:generate', '--', now]);


### PR DESCRIPTION
Uses Codex's workspace-write approval mode without the incompatible duplicate sandbox option.