### PR TITLE
fix: bound host Guardian subprocesses

### DIFF
--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -34,6 +34,10 @@ Guardian branch; CI remains responsible for deterministic validation of that
 commit. The host's Codex and GitHub CLI credentials stay in the service
 account and are never added to this repository or passed to CI.
 
+Each subprocess has a hard deadline: 15 minutes for Codex and five minutes
+for each deterministic command. A deadline expires the subprocess group,
+records a failure, and releases the cron lock for the next scheduled attempt.
+
 All filesystem, time, network, process, and command-line behavior crosses injectable interfaces.
 Methods receive referenced timestamps from callers; strategy logic does not read ambient time.
 

--- a/src/master-plan-controller/__tests__/host-guardian-supervisor.test.ts
+++ b/src/master-plan-controller/__tests__/host-guardian-supervisor.test.ts
@@ -8,6 +8,8 @@ const config: HostGuardianConfig = {
   statePath: '.guardian/host-guardian-state.json',
   intervalMs: 60 * 60 * 1_000,
   codexModel: 'gpt-5.6-sol',
+  codexTimeoutMs: 15 * 60 * 1_000,
+  deterministicCommandTimeoutMs: 5 * 60 * 1_000,
 };
 
 describe('host Guardian supervisor', () => {
@@ -19,8 +21,8 @@ describe('host Guardian supervisor', () => {
 
     expect(result.ran).toBe(true);
     expect(process.requests).toEqual([
-      expect.objectContaining({ command: 'codex', args: expect.arrayContaining(['exec', '--approve-for-me', '--ephemeral', '-m', 'gpt-5.6-sol']) }),
-      expect.objectContaining({ command: 'npm', args: ['run', 'strategy:generate', '--', NOW] }),
+      expect.objectContaining({ command: 'codex', timeoutMs: 15 * 60 * 1_000, args: expect.arrayContaining(['exec', '--approve-for-me', '--ephemeral', '-m', 'gpt-5.6-sol']) }),
+      expect.objectContaining({ command: 'npm', timeoutMs: 5 * 60 * 1_000, args: ['run', 'strategy:generate', '--', NOW] }),
       expect.objectContaining({ command: 'npm', args: ['run', 'strategy:execute', '--', NOW] }),
       expect.objectContaining({ command: 'npm', args: ['run', 'strategy:verify'] }),
       expect.objectContaining({ command: 'npm', args: ['run', 'docs:verify'] }),

--- a/src/master-plan-controller/__tests__/runtime-adapters.test.ts
+++ b/src/master-plan-controller/__tests__/runtime-adapters.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { NodeFileSystem, normalizeRepositoryPath, normalizeRepositoryText } from '../runtime-adapters.js';
+import { NodeFileSystem, NodeProcess, normalizeRepositoryPath, normalizeRepositoryText } from '../runtime-adapters.js';
 
 describe('repository filesystem normalization', () => {
   it('returns portable repository paths from platform-specific paths', () => {
@@ -15,5 +15,18 @@ describe('repository filesystem normalization', () => {
 
   it('treats an absent output directory as an empty portable file set', async () => {
     await expect(new NodeFileSystem('.').listFiles('strategy/absent-output-fixture/')).resolves.toEqual([]);
+  });
+});
+
+describe('node process adapter', () => {
+  it('terminates a timed-out command and reports a bounded failure', async () => {
+    const result = await new NodeProcess().run({
+      command: process.execPath,
+      args: ['-e', 'setInterval(() => undefined, 1_000)'],
+      timeoutMs: 50,
+    });
+
+    expect(result.exitCode).toBe(124);
+    expect(result.stderr).toContain('Process timed out after 50ms.');
   });
 });

--- a/src/master-plan-controller/cli/host-guardian-supervisor-main.ts
+++ b/src/master-plan-controller/cli/host-guardian-supervisor-main.ts
@@ -10,6 +10,8 @@ async function main(): Promise<void> {
       statePath: '.guardian/host-guardian-state.json',
       intervalMs: 60 * 60 * 1_000,
       codexModel: process.env['MASTER_PLAN_CODEX_MODEL'] ?? 'gpt-5.6-sol',
+      codexTimeoutMs: 15 * 60 * 1_000,
+      deterministicCommandTimeoutMs: 5 * 60 * 1_000,
     },
   );
   process.stdout.write(`${JSON.stringify(result)}\n`);

--- a/src/master-plan-controller/host-guardian-supervisor.ts
+++ b/src/master-plan-controller/host-guardian-supervisor.ts
@@ -6,6 +6,8 @@ export interface HostGuardianConfig {
   statePath: string;
   intervalMs: number;
   codexModel: string;
+  codexTimeoutMs: number;
+  deterministicCommandTimeoutMs: number;
 }
 
 export interface HostGuardianDeps {
@@ -22,6 +24,8 @@ export async function runHostGuardianSupervisor(
 ): Promise<{ ran: boolean }> {
   const now = deps.clock.now();
   assertTimestamp(now);
+  assertPositiveDuration(config.codexTimeoutMs, 'Codex timeout');
+  assertPositiveDuration(config.deterministicCommandTimeoutMs, 'deterministic command timeout');
   const state = await loadState(deps.fs, config.statePath);
   if (!isDue(state.completedAt, config.intervalMs, now)) return { ran: false };
 
@@ -37,6 +41,7 @@ export async function runHostGuardianSupervisor(
   }
   const summary = await deps.process.run({
     command: 'npm', args: ['run', 'guardian:summary', '--', now, generation, execution], cwd: config.workingDirectory,
+    timeoutMs: config.deterministicCommandTimeoutMs,
   });
   if (summary.exitCode !== 0) {
     throw new Error(`host guardian command failed: ${summary.stderr.trim() || summary.stdout.trim() || `exit code ${summary.exitCode}`}`);
@@ -55,11 +60,12 @@ function commands(now: string, config: HostGuardianConfig): ProcessRequest[] {
     'Respect strategy authority boundaries and do not use credentials, push, commit, alter CI, or perform external actions.',
     'Work only in this worktree. If no safe material improvement is available, make no change and exit.',
   ].join(' ');
-  const npm = (args: string[]): ProcessRequest => ({ command: 'npm', args, cwd });
+  const npm = (args: string[]): ProcessRequest => ({ command: 'npm', args, cwd, timeoutMs: config.deterministicCommandTimeoutMs });
   const agent: ProcessRequest = {
     command: 'codex',
     args: ['exec', '--approve-for-me', '--json', '--color', 'never', '--ephemeral', '-m', config.codexModel, '-C', cwd, prompt],
     cwd,
+    timeoutMs: config.codexTimeoutMs,
   };
   const generation = npm(['run', 'strategy:generate', '--', now]);
   const execution = npm(['run', 'strategy:execute', '--', now]);
@@ -91,8 +97,12 @@ function isMissingFile(error: unknown): boolean {
 }
 
 function isDue(last: string | undefined, intervalMs: number, now: string): boolean {
-  if (!Number.isSafeInteger(intervalMs) || intervalMs <= 0) throw new Error('host Guardian interval must be positive');
+  assertPositiveDuration(intervalMs, 'host Guardian interval');
   return !last || Date.parse(now) - Date.parse(last) >= intervalMs;
+}
+
+function assertPositiveDuration(value: number, label: string): void {
+  if (!Number.isSafeInteger(value) || value <= 0) throw new Error(`${label} must be positive`);
 }
 
 function assertTimestamp(value: string): void {

--- a/src/master-plan-controller/ports.ts
+++ b/src/master-plan-controller/ports.ts
@@ -46,6 +46,7 @@ export interface ProcessRequest {
   args: string[];
   cwd?: string;
   environment?: Record<string, string>;
+  timeoutMs?: number;
 }
 
 export interface ProcessResult {

--- a/src/master-plan-controller/runtime-adapters.ts
+++ b/src/master-plan-controller/runtime-adapters.ts
@@ -113,20 +113,42 @@ export class NodeScheduler implements SchedulerPort {
 
 export class NodeProcess implements ProcessPort {
   async run(request: ProcessRequest): Promise<ProcessResult> {
+    if (request.timeoutMs !== undefined && (!Number.isSafeInteger(request.timeoutMs) || request.timeoutMs <= 0)) {
+      throw new Error('process timeout must be positive');
+    }
     return new Promise((resolveResult, reject) => {
       const child = spawn(request.command, request.args, {
         cwd: request.cwd,
         env: request.environment === undefined ? process.env : { ...process.env, ...request.environment },
         shell: false,
+        detached: process.platform !== 'win32',
       });
       let stdout = '';
       let stderr = '';
+      let timedOut = false;
+      const timeout = request.timeoutMs === undefined ? undefined : setTimeout(() => {
+        timedOut = true;
+        if (child.pid === undefined) return;
+        if (process.platform === 'win32') child.kill('SIGTERM');
+        else process.kill(-child.pid, 'SIGTERM');
+      }, request.timeoutMs);
+      timeout?.unref();
       child.stdout.setEncoding('utf8');
       child.stderr.setEncoding('utf8');
       child.stdout.on('data', (chunk: string) => { stdout += chunk; });
       child.stderr.on('data', (chunk: string) => { stderr += chunk; });
-      child.on('error', reject);
-      child.on('close', (exitCode) => resolveResult({ exitCode: exitCode ?? 1, stdout, stderr }));
+      child.on('error', (error) => {
+        if (timeout) clearTimeout(timeout);
+        reject(error);
+      });
+      child.on('close', (exitCode) => {
+        if (timeout) clearTimeout(timeout);
+        resolveResult({
+          exitCode: timedOut ? 124 : exitCode ?? 1,
+          stdout,
+          stderr: timedOut ? `${stderr}\nProcess timed out after ${request.timeoutMs}ms.`.trim() : stderr,
+        });
+      });
     });
   }
 }


### PR DESCRIPTION
Stops a stalled Codex or validation command from holding the host Guardian lock indefinitely. Adds explicit process deadlines and tests.