### PR TITLE
fix: run host Guardian without approval prompts

### DIFF
--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -28,7 +28,7 @@ updates are integrated after deterministic verification.
 
 The authenticated repository host, not GitHub Actions, owns scheduled Guardian
 execution. Its cron entry runs `scripts/run-host-guardian-cycle.sh`, which
-locks a dedicated Git worktree, invokes Codex with workspace-write sandboxing,
+locks a dedicated Git worktree, invokes Codex non-interactively with workspace-write sandboxing,
 then performs one deterministic bounded cycle. A changed cycle is pushed on a
 Guardian branch; CI remains responsible for deterministic validation of that
 commit. The host's Codex and GitHub CLI credentials stay in the service

--- a/src/master-plan-controller/__tests__/host-guardian-supervisor.test.ts
+++ b/src/master-plan-controller/__tests__/host-guardian-supervisor.test.ts
@@ -21,7 +21,7 @@ describe('host Guardian supervisor', () => {
 
     expect(result.ran).toBe(true);
     expect(process.requests).toEqual([
-      expect.objectContaining({ command: 'codex', timeoutMs: 15 * 60 * 1_000, args: expect.arrayContaining(['exec', '--approve-for-me', '--ephemeral', '-m', 'gpt-5.6-sol']) }),
+      expect.objectContaining({ command: 'codex', timeoutMs: 15 * 60 * 1_000, args: expect.arrayContaining(['--ask-for-approval', 'never', 'exec', '--sandbox', 'workspace-write', '--ephemeral', '-m', 'gpt-5.6-sol']) }),
       expect.objectContaining({ command: 'npm', timeoutMs: 5 * 60 * 1_000, args: ['run', 'strategy:generate', '--', NOW] }),
       expect.objectContaining({ command: 'npm', args: ['run', 'strategy:execute', '--', NOW] }),
       expect.objectContaining({ command: 'npm', args: ['run', 'strategy:verify'] }),
@@ -30,7 +30,7 @@ describe('host Guardian supervisor', () => {
       expect.objectContaining({ command: 'npm', args: ['test'] }),
       expect.objectContaining({ command: 'npm', args: ['run', 'guardian:summary', '--', NOW, '{}', '{}'] }),
     ]);
-    expect(process.requests[0].args).not.toContain('--sandbox');
+    expect(process.requests[0].args).not.toContain('--approve-for-me');
     expect(process.requests[0].args.at(-1)).toContain('Only modify docs/ and strategy/.');
     expect(JSON.parse(await fs.readText(config.statePath))).toEqual({ version: 1, completedAt: NOW });
   });

--- a/src/master-plan-controller/host-guardian-supervisor.ts
+++ b/src/master-plan-controller/host-guardian-supervisor.ts
@@ -63,7 +63,7 @@ function commands(now: string, config: HostGuardianConfig): ProcessRequest[] {
   const npm = (args: string[]): ProcessRequest => ({ command: 'npm', args, cwd, timeoutMs: config.deterministicCommandTimeoutMs });
   const agent: ProcessRequest = {
     command: 'codex',
-    args: ['exec', '--approve-for-me', '--json', '--color', 'never', '--ephemeral', '-m', config.codexModel, '-C', cwd, prompt],
+    args: ['--ask-for-approval', 'never', 'exec', '--sandbox', 'workspace-write', '--json', '--color', 'never', '--ephemeral', '-m', config.codexModel, '-C', cwd, prompt],
     cwd,
     timeoutMs: config.codexTimeoutMs,
   };


### PR DESCRIPTION
Uses Codex non-interactive approval policy with workspace-write sandboxing so scheduled Guardian cycles cannot wait for stdin.