### PR TITLE
fix: close stdin for host Guardian commands

### DIFF
--- a/src/master-plan-controller/__tests__/runtime-adapters.test.ts
+++ b/src/master-plan-controller/__tests__/runtime-adapters.test.ts
@@ -19,6 +19,16 @@ describe('repository filesystem normalization', () => {
 });
 
 describe('node process adapter', () => {
+  it('closes stdin for an unattended command', async () => {
+    const result = await new NodeProcess().run({
+      command: process.execPath,
+      args: ['-e', "process.stdin.on('end', () => process.stdout.write('stdin closed'))"],
+      timeoutMs: 500,
+    });
+
+    expect(result).toEqual({ exitCode: 0, stdout: '', stderr: '' });
+  });
+
   it('terminates a timed-out command and reports a bounded failure', async () => {
     const result = await new NodeProcess().run({
       command: process.execPath,

--- a/src/master-plan-controller/runtime-adapters.ts
+++ b/src/master-plan-controller/runtime-adapters.ts
@@ -122,6 +122,7 @@ export class NodeProcess implements ProcessPort {
         env: request.environment === undefined ? process.env : { ...process.env, ...request.environment },
         shell: false,
         detached: process.platform !== 'win32',
+        stdio: ['ignore', 'pipe', 'pipe'],
       });
       let stdout = '';
       let stderr = '';


### PR DESCRIPTION
Unattended Codex commands now receive EOF instead of an open stdin pipe, so they do not wait forever for additional input.