### PR TITLE
fix: recover interrupted host Guardian cycles

### DIFF
--- a/scripts/run-host-guardian-cycle.sh
+++ b/scripts/run-host-guardian-cycle.sh
@@ -14,13 +14,57 @@ mkdir -p "$runtime_dir"
 exec 9>"$lock_file"
 flock -n 9 || exit 0
 
+has_open_guardian_pr() {
+  test "$(gh pr list --repo "$repository" --head "$branch" --state open --json number --jq 'length')" -gt 0
+}
+
+publish_pending_cycle() {
+  if test -z "$(git status --porcelain --untracked-files=no)"; then return; fi
+  if git diff HEAD --name-only | rg -qv '^(docs|strategy)/'; then
+    echo "Refusing to publish Guardian changes outside docs/ or strategy/." >&2
+    exit 1
+  fi
+  npm run strategy:verify
+  npm run docs:verify
+  npm run lint
+  npm test
+  git add docs strategy
+  git diff --cached --quiet && return
+  git commit -m 'chore: run host guardian cycle'
+  git push --set-upstream origin "$branch"
+  if ! has_open_guardian_pr; then
+    gh pr create --base main --head "$branch" --title 'chore: run host guardian cycle' \
+      --body 'Host-owned Codex Guardian cycle; deterministic CI validates the result.'
+  fi
+}
+
 if test -n "$(git -C "$repo_root" status --porcelain)"; then
   echo "Refusing to run: primary checkout has uncommitted changes." >&2
   exit 1
 fi
 git -C "$repo_root" fetch origin main
 if test -e "$worktree_dir/.git"; then
-  test -z "$(git -C "$worktree_dir" status --porcelain --untracked-files=no)"
+  git -C "$worktree_dir" config user.name 'MASTER_PLAN Guardian'
+  git -C "$worktree_dir" config user.email 'guardian@users.noreply.github.com'
+  if test -n "$(git -C "$worktree_dir" status --porcelain --untracked-files=no)"; then
+    (
+      cd "$worktree_dir"
+      publish_pending_cycle
+    )
+    exit 0
+  fi
+  if test "$(git -C "$worktree_dir" rev-list --count origin/main..HEAD)" -gt 0; then
+    if git -C "$worktree_dir" diff --quiet origin/main...HEAD; then
+      git -C "$worktree_dir" reset --hard origin/main
+    elif has_open_guardian_pr; then
+      echo "Guardian PR remains open; waiting for deterministic CI."
+    else
+      git -C "$worktree_dir" push --set-upstream origin "$branch"
+      gh pr create --base main --head "$branch" --title 'chore: run host guardian cycle' \
+        --body 'Host-owned Codex Guardian cycle; deterministic CI validates the result.'
+    fi
+    if ! git -C "$worktree_dir" diff --quiet origin/main...HEAD; then exit 0; fi
+  fi
   git -C "$worktree_dir" fetch origin main
   git -C "$worktree_dir" reset --hard origin/main
 else
@@ -28,7 +72,7 @@ else
 fi
 if test ! -e "$worktree_dir/node_modules"; then ln -s "$repo_root/node_modules" "$worktree_dir/node_modules"; fi
 
-if test "$(gh pr list --repo "$repository" --head "$branch" --state open --json number --jq 'length')" -gt 0; then
+if has_open_guardian_pr; then
   echo "Guardian PR remains open; waiting for deterministic CI."
   exit 0
 fi
@@ -38,13 +82,5 @@ git -C "$worktree_dir" config user.email 'guardian@users.noreply.github.com'
 (
   cd "$worktree_dir"
   npm run guardian:host-cycle
-  if test -n "$(git status --porcelain --untracked-files=no)"; then
-    git add docs strategy
-    git commit -m 'chore: run host guardian cycle'
-  fi
-  if test "$(git rev-list --count origin/main..HEAD)" -gt 0; then
-    git push --set-upstream origin "$branch"
-    gh pr create --base main --head "$branch" --title 'chore: run host guardian cycle' \
-      --body 'Host-owned Codex Guardian cycle; deterministic CI validates the result.'
-  fi
+  publish_pending_cycle
 )

--- a/src/master-plan-controller/__tests__/workflow-governance.test.ts
+++ b/src/master-plan-controller/__tests__/workflow-governance.test.ts
@@ -52,6 +52,15 @@ describe('streamlined update workflows', () => {
     expect(guardian).not.toContain('git push');
   });
 
+  it('recovers validated host Guardian work left by an interrupted publisher', async () => {
+    const launcher = await fileSystem.readText('scripts/run-host-guardian-cycle.sh');
+    expect(launcher).toContain('publish_pending_cycle');
+    expect(launcher).toContain('npm run strategy:verify');
+    expect(launcher).toContain('npm run docs:verify');
+    expect(launcher).toContain('npm run lint');
+    expect(launcher).toContain('npm test');
+  });
+
   it('documents CI-only update handling without independent agent-review requirements', async () => {
     const [agents, operations] = await Promise.all([
       fileSystem.readText('AGENTS.md'),


### PR DESCRIPTION
Validates and publishes pending dedicated-worktree changes from an interrupted host Guardian publisher instead of silently wedging future cron cycles.